### PR TITLE
データベースリファクタ

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -13,6 +13,8 @@ import { CONFIG } from './config/config';
 import { joinVoiceChannel, leftVoiceChannel } from './bot/function/voice';
 import { TypeOrm } from './model/typeorm/typeorm';
 import * as logger from './common/logger';
+import { ItemRepository } from './model/repository/itemRepository';
+import { GACHA_LIST } from './constant/gacha/gachaList';
 
 dotenv.config();
 
@@ -55,6 +57,7 @@ app.listen(port, hostName);
  * Bot Process
  * =======================
  */
+console.log('==================================================');
 
 const commands = [
     new SlashCommandBuilder().setName('ping').setDescription('replies with pong'),
@@ -92,12 +95,12 @@ DISCORD_CLIENT.once('ready', async () => {
     TypeOrm.dataSource
         .initialize()
         .then(async () => {
+            await new ItemRepository().init(GACHA_LIST);
             logger.info('system', 'db-init', 'success');
         })
         .catch((e) => {
             logger.error('system', 'db-init', e);
         });
-    console.log('==================================================');
     logger.info(undefined, 'ready', `discord bot logged in: ${DISCORD_CLIENT.user?.tag}`);
 });
 

--- a/src/bot/commands.ts
+++ b/src/bot/commands.ts
@@ -4,6 +4,8 @@ import * as BotFunctions from './function';
 import { PlaylistRepository } from '../model/repository/playlistRepository';
 import ytpl from 'ytpl';
 import * as logger from '../common/logger';
+import { GachaRepository } from '../model/repository/gachaRepository';
+import { ItemRepository } from '../model/repository/itemRepository';
 
 /**
  * 渡されたコマンドから処理を実行する
@@ -390,8 +392,9 @@ export async function ping(message: Message) {
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export async function debug(message: Message, args?: string[]) {
-    const channel = message.member?.voice.channel as VoiceBasedChannel;
-    await BotFunctions.Music.playMusic(channel);
+    const r = new ItemRepository();
+    const g = await r.get('UUR');
+    message.reply(JSON.stringify(g));
 }
 
 /**

--- a/src/bot/commands.ts
+++ b/src/bot/commands.ts
@@ -392,9 +392,8 @@ export async function ping(message: Message) {
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export async function debug(message: Message, args?: string[]) {
-    const r = new ItemRepository();
-    const g = await r.get('UUR');
-    message.reply(JSON.stringify(g));
+    const channel = message.member?.voice.channel as VoiceBasedChannel;
+    await BotFunctions.Music.playMusic(channel);
 }
 
 /**

--- a/src/bot/function/gacha.ts
+++ b/src/bot/function/gacha.ts
@@ -10,6 +10,7 @@ import { CONFIG } from '../../config/config';
 import { GACHA_MONEY_LIST } from '../../constant/gacha/gachaList';
 import { GachaRepository } from '../../model/repository/gachaRepository';
 import { UsersRepository } from '../../model/repository/usersRepository';
+import * as Models from '../../model/models';
 
 /**
  * ランダムにガチャを一度引く
@@ -75,211 +76,258 @@ function getGachaOnce(): Gacha {
  * @returns
  */
 export async function pickGacha(message: Message, args?: string[]) {
+    if (args != undefined && args.length > 0) {
+        pickExtra(message, args);
+    } else {
+        pickNormal(message);
+    }
+}
+
+/**
+ * 指定された条件でガチャを引く
+ * @param message
+ * @param args
+ * @returns
+ */
+export async function pickExtra(message: Message, args: string[]) {
     const gachaList: Gacha[] = [];
 
-    if (args != undefined && args.length > 0) {
-        if (args[0] === 'reset') {
-            if (!CONFIG.ADMIN_USER_ID.includes(message.author.id)) {
+    if (args[0] === 'reset') {
+        if (!CONFIG.ADMIN_USER_ID.includes(message.author.id)) {
+            message.reply({
+                content: `ガチャフラグのリセット権限がないアカウントだよ！管理者にお願いしてね！`
+            });
+            return;
+        }
+        if (args[1]) {
+            const users = new UsersRepository();
+            const user = await users.get(args[1]);
+            if (!user) {
                 message.reply({
-                    content: `ガチャフラグのリセット権限がないアカウントだよ！管理者にお願いしてね！`
+                    content: `リセットしようとするユーザが登録されてないみたい…？`
                 });
                 return;
             }
-            if (args[1]) {
-                const users = new UsersRepository();
-                const user = await users.get(args[1]);
-                if (!user) {
-                    message.reply({
-                        content: `リセットしようとするユーザが登録されてないみたい…？`
-                    });
-                    return;
-                }
-                await users.resetGacha(args[1]);
-                message.reply({
-                    content: `${user?.userName ? user.userName : user.id} さんのガチャフラグをリセットしたよ～！`
-                });
-            }
-            return;
+            await users.resetGacha(args[1]);
+            message.reply({
+                content: `${user?.user_name ? user.user_name : user.id} さんのガチャフラグをリセットしたよ～！`
+            });
         }
+        return;
+    }
 
-        const num = Number(args[0]);
-        if (num) {
-            for (let i = 0; i < num; i++) {
-                const gacha = getGachaOnce();
-                gachaList.push(gacha);
-            }
-        } else {
-            do {
-                const gacha = getGachaOnce();
-                gachaList.push(gacha);
-                if (gacha.rare === args[0].toUpperCase()) {
-                    if (!gacha.description.includes('連チケット')) {
-                        break;
-                    }
-                }
-                if (
-                    gacha.description.includes(args[0]) &&
-                    !['C', 'UC', 'R', 'SR', 'SSR', 'UR', 'UUR'].find((r) => r === args[0].toUpperCase())
-                ) {
-                    break;
-                }
-                if (gachaList.length > 1_000_000) {
-                    const send = new EmbedBuilder()
-                        .setColor('#ff0000')
-                        .setTitle(`エラー`)
-                        .setDescription(`1,000,000回引いても該当の等級が出なかった`);
-
-                    message.reply({ content: `ガチャ、出なかったみたい・・・`, embeds: [send] });
-                    return;
-                }
-                // eslint-disable-next-line no-constant-condition
-            } while (true);
-        }
-
-        const rareList = [...new Set(gachaList.map((g) => g.rare))];
-
-        // 等級と総数
-        const fields = rareList.map((r) => {
-            const length = gachaList.filter((l) => l.rare === r).length;
-            return {
-                name: r,
-                value: length.toString() + ` > 確率: ${((length / gachaList.length) * 100).toFixed(4)}%`
-            };
-        });
-        fields.push({ name: '総数', value: gachaList.length.toString() });
-
-        // 等級の高い順に並び替える
-        const t = gachaList.sort((a, b) => {
-            return a.rank - b.rank;
-        });
-
-        const highTier = t.slice(0, 50);
-        highTier.reverse();
-
-        const send = new EmbedBuilder()
-            .setColor('#ff9900')
-            .setTitle(`${gachaList.length}連の結果: 高い順から50個まで表示しています`)
-            .setDescription(`${highTier.map((g) => `[${g.rare}] ` + g.description).join('\n')}`)
-            .setFields(fields)
-            .setThumbnail('https://s3-ap-northeast-1.amazonaws.com/rim.public-upload/pic/gacha.png');
-
-        message.reply({ content: `ガチャを${gachaList.length}回ひいたよ！(_**景品無効**_)`, embeds: [send] });
-    } else {
-        const users = new UsersRepository();
-        const user = await users.get(message.author.id);
-
-        if (user) {
-            if (user.gachaDate) {
-                if (user.gachaDate >= dayjs().hour(0).minute(0).second(0).toDate()) {
-                    const send = new EmbedBuilder()
-                        .setColor('#ff0000')
-                        .setTitle(`エラー`)
-                        .setDescription(`ガチャ抽選済`);
-
-                    message.reply({ content: `もう抽選してるみたい！2回目はだめだよ！`, embeds: [send] });
-                    return;
-                }
-            }
-        } else {
-            await users.save({ id: message.author.id, userName: message.author.tag });
-        }
-
-        for (let i = 0; i < 10; i++) {
+    const num = Number(args[0]);
+    if (num) {
+        for (let i = 0; i < num; i++) {
             const gacha = getGachaOnce();
             gachaList.push(gacha);
         }
-
-        // 10連チケットを引いた分だけ加算する
-        let ticket_10 = gachaList.filter((g) => g.description === ':tickets: ガチャ+10連チケット').length;
-        let ticket_20 = gachaList.filter((g) => g.description === ':tickets: ガチャ+20連チケット').length;
+    } else {
         do {
-            const tempList = [];
-
-            if (ticket_10 > 0) {
-                for (let i = 0; i < 10; i++) {
-                    const gacha = getGachaOnce();
-                    tempList.push(gacha);
-                    gachaList.push(gacha);
+            const gacha = getGachaOnce();
+            gachaList.push(gacha);
+            if (gacha.rare === args[0].toUpperCase()) {
+                if (!gacha.description.includes('連チケット')) {
+                    break;
                 }
-                ticket_10--;
-            } else if (ticket_20 > 0) {
-                for (let i = 0; i < 20; i++) {
-                    const gacha = getGachaOnce();
-                    tempList.push(gacha);
-                    gachaList.push(gacha);
-                }
-                ticket_20--;
             }
-
-            ticket_10 += tempList.filter((g) => g.description === ':tickets: ガチャ+10連チケット').length;
-            ticket_20 += tempList.filter((g) => g.description === ':tickets: ガチャ+20連チケット').length;
-
-            if (ticket_10 <= 0 && ticket_20 <= 0) {
+            if (
+                gacha.description.includes(args[0]) &&
+                !['C', 'UC', 'R', 'SR', 'SSR', 'UR', 'UUR'].find((r) => r === args[0].toUpperCase())
+            ) {
                 break;
+            }
+            if (gachaList.length > 1_000_000) {
+                const send = new EmbedBuilder()
+                    .setColor('#ff0000')
+                    .setTitle(`エラー`)
+                    .setDescription(`1,000,000回引いても該当の等級が出なかった`);
+
+                message.reply({ content: `ガチャ、出なかったみたい・・・`, embeds: [send] });
+                return;
             }
             // eslint-disable-next-line no-constant-condition
         } while (true);
+    }
 
-        const t = gachaList.sort((a, b) => {
-            return a.rank - b.rank;
-        });
+    const rareList = [...new Set(gachaList.map((g) => g.rare))];
 
-        const highTier = t.slice(0, 50);
-        t.reverse();
+    // 等級と総数
+    const fields = rareList.map((r) => {
+        const length = gachaList.filter((l) => l.rare === r).length;
+        return {
+            name: r,
+            value: length.toString() + ` > 確率: ${((length / gachaList.length) * 100).toFixed(4)}%`
+        };
+    });
+    fields.push({ name: '総数', value: gachaList.length.toString() });
 
-        const gachaTable = new GachaRepository();
-        const nowTime = dayjs().toDate();
-        const createTables = t.map((g) => {
-            return {
-                user_id: message.author.id,
-                gachaTime: nowTime,
-                rare: g.rare,
-                rank: g.rank,
-                description: g.description
-            };
-        });
+    // 等級の高い順に並び替える
+    const t = gachaList.sort((a, b) => {
+        return a.rank - b.rank;
+    });
 
-        await gachaTable.save(createTables);
+    const highTier = t.slice(0, 50);
+    highTier.reverse();
 
-        await users.save({
-            id: message.author.id,
-            userName: message.author.tag,
-            gachaDate: dayjs().toDate()
-        });
-        const presents = t.filter((g) => g.description.includes('_**プレゼント**_'));
-        const desc = t.map((g) => `[${g.rare}] ` + g.description).join('\n');
+    const send = new EmbedBuilder()
+        .setColor('#ff9900')
+        .setTitle(`${gachaList.length}連の結果: 高い順から50個まで表示しています`)
+        .setDescription(`${highTier.map((g) => `[${g.rare}] ` + g.description).join('\n')}`)
+        .setFields(fields)
+        .setThumbnail('https://s3-ap-northeast-1.amazonaws.com/rim.public-upload/pic/gacha.png');
 
-        if (t.length > 99) {
-            const send = new EmbedBuilder()
-                .setColor('#ff9900')
-                .setTitle(`${gachaList.length}連の結果: 高い順に50要素のみ抜き出しています`)
-                .setDescription(`${highTier.map((g) => `[${g.rare}] ` + g.description).join('\n')}`)
-                .setThumbnail('https://s3-ap-northeast-1.amazonaws.com/rim.public-upload/pic/gacha.png');
-            message.reply({ content: `ガチャだよ！からんころーん！(景品は一日の最初の一回のみです)`, embeds: [send] });
-            if (presents.length > 0) {
-                const send = new EmbedBuilder()
-                    .setColor('#ff9900')
-                    .setTitle('プレゼントだ～！おめでと～！！')
-                    .setDescription(presents.map((p) => `${p.rare}: ${p.description}`).join('\n'))
-                    .setFields({ name: '通知:', value: '<@246007305156558848>' });
-                message.channel.send({ embeds: [send] });
-            }
-        } else {
-            const send = new EmbedBuilder()
-                .setColor('#ff9900')
-                .setTitle(`${gachaList.length}連の結果`)
-                .setDescription(`${desc}`)
-                .setThumbnail('https://s3-ap-northeast-1.amazonaws.com/rim.public-upload/pic/gacha.png');
-            message.reply({ content: `ガチャだよ！からんころーん！(景品は一日の最初の一回のみです)`, embeds: [send] });
-            if (presents.length > 0) {
-                const send = new EmbedBuilder()
-                    .setColor('#ff9900')
-                    .setTitle('プレゼントだ～！おめでと～！！')
-                    .setDescription(presents.map((p) => `${p.rare}: ${p.description}`).join('\n'))
-                    .setFields({ name: '通知用:', value: '<@246007305156558848>' });
-                message.channel.send({ embeds: [send] });
+    message.reply({ content: `ガチャを${gachaList.length}回ひいたよ！(_**景品無効**_)`, embeds: [send] });
+}
+
+/**
+ * 通常ガチャを引く
+ * @param message
+ * @returns
+ */
+export async function pickNormal(message: Message) {
+    const gachaList = [];
+
+    const users = new UsersRepository();
+    const user = await users.get(message.author.id);
+
+    if (user) {
+        if (user.last_pick_date) {
+            if (user.last_pick_date >= dayjs().hour(0).minute(0).second(0).toDate()) {
+                const send = new EmbedBuilder().setColor('#ff0000').setTitle(`エラー`).setDescription(`ガチャ抽選済`);
+
+                message.reply({ content: `もう抽選してるみたい！2回目はだめだよ！`, embeds: [send] });
+                return;
             }
         }
+    } else {
+        await users.save({ id: message.author.id, user_name: message.author.tag });
+    }
+
+    for (let i = 0; i < 10; i++) {
+        const gacha = getGachaOnce();
+        gachaList.push(gacha);
+    }
+
+    // 10連チケットを引いた分だけ加算する
+    let ticket_10 = gachaList.filter((g) => g.description === ':tickets: ガチャ+10連チケット').length;
+    let ticket_20 = gachaList.filter((g) => g.description === ':tickets: ガチャ+20連チケット').length;
+    do {
+        const tempList = [];
+
+        if (ticket_10 > 0) {
+            for (let i = 0; i < 10; i++) {
+                const gacha = getGachaOnce();
+                tempList.push(gacha);
+                gachaList.push(gacha);
+            }
+            ticket_10--;
+        } else if (ticket_20 > 0) {
+            for (let i = 0; i < 20; i++) {
+                const gacha = getGachaOnce();
+                tempList.push(gacha);
+                gachaList.push(gacha);
+            }
+            ticket_20--;
+        }
+
+        ticket_10 += tempList.filter((g) => g.description === ':tickets: ガチャ+10連チケット').length;
+        ticket_20 += tempList.filter((g) => g.description === ':tickets: ガチャ+20連チケット').length;
+
+        if (ticket_10 <= 0 && ticket_20 <= 0) {
+            break;
+        }
+        // eslint-disable-next-line no-constant-condition
+    } while (true);
+
+    const t = gachaList.sort((a, b) => {
+        return a.rank - b.rank;
+    });
+
+    const highTier = t.slice(0, 50);
+    t.reverse();
+
+    const gachaTable = new GachaRepository();
+    const nowTime = dayjs().toDate();
+    const createTables = t.map((g) => {
+        return {
+            user_id: message.author.id,
+            gachaTime: nowTime,
+            rare: g.rare,
+            rank: g.rank,
+            description: g.description
+        };
+    });
+
+    await gachaTable.save(createTables);
+
+    await users.save({
+        id: message.author.id,
+        user_name: message.author.tag,
+        last_pick_date: dayjs().toDate()
+    });
+    const presents = t.filter((g) => g.description.includes('_**プレゼント**_'));
+    const desc = t.map((g) => `[${g.rare}] ` + g.description).join('\n');
+
+    if (t.length > 99) {
+        const send = new EmbedBuilder()
+            .setColor('#ff9900')
+            .setTitle(`${gachaList.length}連の結果: 高い順に50要素のみ抜き出しています`)
+            .setDescription(`${highTier.map((g) => `[${g.rare}] ` + g.description).join('\n')}`)
+            .setThumbnail('https://s3-ap-northeast-1.amazonaws.com/rim.public-upload/pic/gacha.png');
+        message.reply({ content: `ガチャだよ！からんころーん！(景品は一日の最初の一回のみです)`, embeds: [send] });
+        if (presents.length > 0) {
+            const send = new EmbedBuilder()
+                .setColor('#ff9900')
+                .setTitle('プレゼントだ～！おめでと～！！')
+                .setDescription(presents.map((p) => `${p.rare}: ${p.description}`).join('\n'))
+                .setFields({ name: '通知:', value: '<@246007305156558848>' });
+            message.channel.send({ embeds: [send] });
+        }
+    } else {
+        const send = new EmbedBuilder()
+            .setColor('#ff9900')
+            .setTitle(`${gachaList.length}連の結果`)
+            .setDescription(`${desc}`)
+            .setThumbnail('https://s3-ap-northeast-1.amazonaws.com/rim.public-upload/pic/gacha.png');
+        message.reply({ content: `ガチャだよ！からんころーん！(景品は一日の最初の一回のみです)`, embeds: [send] });
+        if (presents.length > 0) {
+            const send = new EmbedBuilder()
+                .setColor('#ff9900')
+                .setTitle('プレゼントだ～！おめでと～！！')
+                .setDescription(presents.map((p) => `${p.rare}: ${p.description}`).join('\n'))
+                .setFields({ name: '通知用:', value: '<@246007305156558848>' });
+            message.channel.send({ embeds: [send] });
+        }
+    }
+}
+
+/**
+ * FIXME: 未実装
+ * @param message
+ */
+export async function getPresent(message: Message) {
+    const gachaRepository = new GachaRepository();
+    const gachaList = await gachaRepository.getPresents(message.author.id);
+
+    if (gachaList.length > 0) {
+        const presents: { gacha: Models.Gacha; count: number }[] = [];
+
+        gachaList.map((g) => {
+            const p = presents.find((p) => p.gacha.item_id === g.item_id);
+            if (p != undefined) {
+                p.count++;
+            } else {
+                presents.push({ gacha: g, count: 1 });
+            }
+        });
+
+        const send = new EmbedBuilder()
+            .setColor('#ff9900')
+            .setTitle('当選したプレゼント一覧')
+            .setDescription('')
+            .setFields();
+        message.channel.send({ embeds: [send] });
     }
 }
 

--- a/src/bot/function/gacha.ts
+++ b/src/bot/function/gacha.ts
@@ -32,7 +32,7 @@ export async function getGachaOnce(): Promise<Gacha> {
     const repository = new ItemRepository();
     const rnd = Math.random();
 
-    if (rnd < 0.00002988) {
+    if (rnd < 0.00_0088) {
         const gachaList = await repository.get('UUR');
         const weightList = getWeight(gachaList);
 
@@ -46,7 +46,7 @@ export async function getGachaOnce(): Promise<Gacha> {
             is_present: weightList[index].is_present === 1,
             reroll: weightList[index].reroll
         };
-    } else if (rnd < 0.000137) {
+    } else if (rnd < 0.00_0906) {
         const gachaList = await repository.get('UR');
         const weightList = getWeight(gachaList);
 
@@ -60,7 +60,7 @@ export async function getGachaOnce(): Promise<Gacha> {
             is_present: weightList[index].is_present === 1,
             reroll: weightList[index].reroll
         };
-    } else if (rnd < 0.00866) {
+    } else if (rnd < 0.00_688) {
         const gachaList = await repository.get('SSR');
         const weightList = getWeight(gachaList);
 
@@ -75,7 +75,7 @@ export async function getGachaOnce(): Promise<Gacha> {
             is_present: weightList[index].is_present === 1,
             reroll: weightList[index].reroll
         };
-    } else if (rnd < 0.08928) {
+    } else if (rnd < 0.08_928) {
         const gachaList = await repository.get('SR');
         const weightList = getWeight(gachaList);
 
@@ -90,7 +90,7 @@ export async function getGachaOnce(): Promise<Gacha> {
             is_present: weightList[index].is_present === 1,
             reroll: weightList[index].reroll
         };
-    } else if (rnd < 0.658) {
+    } else if (rnd < 0.65_8) {
         const gachaList = await repository.get('R');
         const weightList = getWeight(gachaList);
         const index = getRndNumber(1, weightList.length) - 1;
@@ -104,7 +104,7 @@ export async function getGachaOnce(): Promise<Gacha> {
             is_present: weightList[index].is_present === 1,
             reroll: weightList[index].reroll
         };
-    } else if (rnd < 0.8889) {
+    } else if (rnd < 0.88_89) {
         const gachaList = await repository.get('UC');
         const weightList = getWeight(gachaList);
 
@@ -145,12 +145,10 @@ export async function getGachaOnce(): Promise<Gacha> {
  */
 export async function pickGacha(message: Message, args?: string[]) {
     if (args != undefined && args.length > 0) {
-        if (args[0] === 'present') {
-            if (args[1] != undefined) {
-                await usePresent(message, args[1]);
-            } else {
-                await getPresent(message);
-            }
+        if (args[0] === 'list') {
+            await getPresent(message);
+        } else if (args[0] === 'use') {
+            await usePresent(message, args[1]);
         } else {
             await pickExtra(message, args);
         }
@@ -404,6 +402,10 @@ export async function getPresent(message: Message) {
             .setTitle('当選したプレゼント一覧')
             .setDescription(description);
         message.channel.send({ embeds: [send] });
+    } else {
+        message.reply({
+            content: `何もプレゼントを持っていないみたい・・・？`
+        });
     }
 }
 

--- a/src/bot/function/gacha.ts
+++ b/src/bot/function/gacha.ts
@@ -7,66 +7,136 @@ import dayjs from 'dayjs';
 import { EmbedBuilder, Message } from 'discord.js';
 import { getRndNumber } from '../../common/common';
 import { CONFIG } from '../../config/config';
-import { GACHA_MONEY_LIST } from '../../constant/gacha/gachaList';
+import { GACHA_LIST } from '../../constant/gacha/gachaList';
 import { GachaRepository } from '../../model/repository/gachaRepository';
 import { UsersRepository } from '../../model/repository/usersRepository';
 import * as Models from '../../model/models';
+import { ItemRepository } from '../../model/repository/itemRepository';
+import { ICON } from '../../constant/constants';
+
+function getWeight(list: Models.Item[]): Models.Item[] {
+    const weightList = [];
+
+    for (const gacha of list) {
+        for (let i = 0; i < gacha.weight; i++) {
+            weightList.push(gacha);
+        }
+    }
+
+    return weightList;
+}
 
 /**
  * ランダムにガチャを一度引く
  * @returns
  */
-function getGachaOnce(): Gacha {
+export async function getGachaOnce(): Promise<Gacha> {
+    const repository = new ItemRepository();
     const rnd = Math.random();
-    let rare;
-    let description;
-    let rank;
 
     if (rnd < 0.00002988) {
-        rare = 'UUR';
-        const index = getRndNumber(1, GACHA_MONEY_LIST.UUR.length) - 1;
-        description = `:crown: ${GACHA_MONEY_LIST.UUR[index]}`;
-        rank = 0;
+        const gachaList = await repository.get('UUR');
+        const weightList = getWeight(gachaList);
+
+        const index = getRndNumber(1, weightList.length) - 1;
+        return {
+            item_id: weightList[index].id,
+            name: weightList[index].name,
+            icon: weightList[index].icon,
+            rare: weightList[index].rare,
+            rank: weightList[index].item_rank.rank,
+            is_present: weightList[index].is_present === 1,
+            reroll: weightList[index].reroll
+        };
     } else if (rnd < 0.000137) {
-        rare = 'UR';
-        const index = getRndNumber(1, GACHA_MONEY_LIST.UR.length) - 1;
-        description = `:sparkles: ${GACHA_MONEY_LIST.UR[index]}`;
-        rank = 1;
+        const gachaList = await repository.get('UR');
+        const weightList = getWeight(gachaList);
+
+        const index = getRndNumber(1, weightList.length) - 1;
+        return {
+            item_id: weightList[index].id,
+            name: weightList[index].name,
+            icon: weightList[index].icon,
+            rare: weightList[index].rare,
+            rank: weightList[index].item_rank.rank,
+            is_present: weightList[index].is_present === 1,
+            reroll: weightList[index].reroll
+        };
     } else if (rnd < 0.00866) {
-        rare = 'SSR';
-        const index = getRndNumber(1, GACHA_MONEY_LIST.SSR.length) - 1;
-        description = `${GACHA_MONEY_LIST.SSR[index].includes('ガチャ+') ? ':tickets:' : ':star:'} ${
-            GACHA_MONEY_LIST.SSR[index]
-        }`;
-        rank = 2;
+        const gachaList = await repository.get('SSR');
+        const weightList = getWeight(gachaList);
+
+        const index = getRndNumber(1, weightList.length) - 1;
+
+        return {
+            item_id: weightList[index].id,
+            name: weightList[index].name,
+            icon: weightList[index].icon,
+            rare: weightList[index].rare,
+            rank: weightList[index].item_rank.rank,
+            is_present: weightList[index].is_present === 1,
+            reroll: weightList[index].reroll
+        };
     } else if (rnd < 0.08928) {
-        rare = 'SR';
-        const index = getRndNumber(1, GACHA_MONEY_LIST.SR.length) - 1;
-        description = `${GACHA_MONEY_LIST.SR[index].includes('ガチャ+') ? ':tickets:' : ''} ${
-            GACHA_MONEY_LIST.SR[index]
-        }`;
-        rank = 3;
+        const gachaList = await repository.get('SR');
+        const weightList = getWeight(gachaList);
+
+        const index = getRndNumber(1, weightList.length) - 1;
+
+        return {
+            item_id: weightList[index].id,
+            name: weightList[index].name,
+            icon: weightList[index].icon,
+            rare: weightList[index].rare,
+            rank: weightList[index].item_rank.rank,
+            is_present: weightList[index].is_present === 1,
+            reroll: weightList[index].reroll
+        };
     } else if (rnd < 0.658) {
-        rare = 'R';
-        const index = getRndNumber(1, GACHA_MONEY_LIST.R.length) - 1;
-        description = ` ${GACHA_MONEY_LIST.R[index]}`;
-        rank = 4;
+        const gachaList = await repository.get('R');
+        const weightList = getWeight(gachaList);
+        const index = getRndNumber(1, weightList.length) - 1;
+
+        return {
+            item_id: weightList[index].id,
+            name: weightList[index].name,
+            icon: weightList[index].icon,
+            rare: weightList[index].rare,
+            rank: weightList[index].item_rank.rank,
+            is_present: weightList[index].is_present === 1,
+            reroll: weightList[index].reroll
+        };
     } else if (rnd < 0.8889) {
-        rare = 'UC';
-        const index = getRndNumber(1, GACHA_MONEY_LIST.UC.length) - 1;
-        description = `${GACHA_MONEY_LIST.UC[index]}`;
-        rank = 5;
+        const gachaList = await repository.get('UC');
+        const weightList = getWeight(gachaList);
+
+        const index = getRndNumber(1, weightList.length) - 1;
+
+        return {
+            item_id: weightList[index].id,
+            name: weightList[index].name,
+            icon: weightList[index].icon,
+            rare: weightList[index].rare,
+            rank: weightList[index].item_rank.rank,
+            is_present: weightList[index].is_present === 1,
+            reroll: weightList[index].reroll
+        };
     } else {
-        rare = 'C';
-        const index = getRndNumber(1, GACHA_MONEY_LIST.C.length) - 1;
-        description = `${GACHA_MONEY_LIST.C[index]}`;
-        rank = 6;
+        const gachaList = await repository.get('C');
+        const weightList = getWeight(gachaList);
+
+        const index = getRndNumber(1, weightList.length) - 1;
+
+        return {
+            item_id: weightList[index].id,
+            name: weightList[index].name,
+            icon: weightList[index].icon,
+            rare: weightList[index].rare,
+            rank: weightList[index].item_rank.rank,
+            is_present: weightList[index].is_present === 1,
+            reroll: weightList[index].reroll
+        };
     }
-    return {
-        rare,
-        description,
-        rank
-    };
 }
 
 /**
@@ -89,7 +159,7 @@ export async function pickGacha(message: Message, args?: string[]) {
  * @param args
  * @returns
  */
-export async function pickExtra(message: Message, args: string[]) {
+async function pickExtra(message: Message, args: string[]) {
     const gachaList: Gacha[] = [];
 
     if (args[0] === 'reset') {
@@ -119,20 +189,20 @@ export async function pickExtra(message: Message, args: string[]) {
     const num = Number(args[0]);
     if (num) {
         for (let i = 0; i < num; i++) {
-            const gacha = getGachaOnce();
+            const gacha = await getGachaOnce();
             gachaList.push(gacha);
         }
     } else {
         do {
-            const gacha = getGachaOnce();
+            const gacha = await getGachaOnce();
             gachaList.push(gacha);
             if (gacha.rare === args[0].toUpperCase()) {
-                if (!gacha.description.includes('連チケット')) {
+                if (gacha.reroll === 0) {
                     break;
                 }
             }
             if (
-                gacha.description.includes(args[0]) &&
+                gacha.name.includes(args[0]) &&
                 !['C', 'UC', 'R', 'SR', 'SSR', 'UR', 'UUR'].find((r) => r === args[0].toUpperCase())
             ) {
                 break;
@@ -173,7 +243,7 @@ export async function pickExtra(message: Message, args: string[]) {
     const send = new EmbedBuilder()
         .setColor('#ff9900')
         .setTitle(`${gachaList.length}連の結果: 高い順から50個まで表示しています`)
-        .setDescription(`${highTier.map((g) => `[${g.rare}] ` + g.description).join('\n')}`)
+        .setDescription(`${highTier.map((g) => `[${g.rare}]${g.icon ? g.icon : ''} ${g.name}`).join('\n')}`)
         .setFields(fields)
         .setThumbnail('https://s3-ap-northeast-1.amazonaws.com/rim.public-upload/pic/gacha.png');
 
@@ -185,7 +255,7 @@ export async function pickExtra(message: Message, args: string[]) {
  * @param message
  * @returns
  */
-export async function pickNormal(message: Message) {
+async function pickNormal(message: Message) {
     const gachaList = [];
 
     const users = new UsersRepository();
@@ -205,36 +275,29 @@ export async function pickNormal(message: Message) {
     }
 
     for (let i = 0; i < 10; i++) {
-        const gacha = getGachaOnce();
+        const gacha = await getGachaOnce();
         gachaList.push(gacha);
     }
 
     // 10連チケットを引いた分だけ加算する
-    let ticket_10 = gachaList.filter((g) => g.description === ':tickets: ガチャ+10連チケット').length;
-    let ticket_20 = gachaList.filter((g) => g.description === ':tickets: ガチャ+20連チケット').length;
+    let ticketRolls = gachaList
+        .filter((g) => g.reroll > 0)
+        .reduce(function (sum, element) {
+            return sum + element.reroll;
+        }, 0);
+
     do {
-        const tempList = [];
-
-        if (ticket_10 > 0) {
-            for (let i = 0; i < 10; i++) {
-                const gacha = getGachaOnce();
-                tempList.push(gacha);
+        let tempList = 0;
+        if (ticketRolls > 0) {
+            for (let i = 0; i < ticketRolls; i++) {
+                const gacha = await getGachaOnce();
                 gachaList.push(gacha);
+                if (gacha.reroll > 0) {
+                    tempList += gacha.reroll;
+                }
             }
-            ticket_10--;
-        } else if (ticket_20 > 0) {
-            for (let i = 0; i < 20; i++) {
-                const gacha = getGachaOnce();
-                tempList.push(gacha);
-                gachaList.push(gacha);
-            }
-            ticket_20--;
-        }
-
-        ticket_10 += tempList.filter((g) => g.description === ':tickets: ガチャ+10連チケット').length;
-        ticket_20 += tempList.filter((g) => g.description === ':tickets: ガチャ+20連チケット').length;
-
-        if (ticket_10 <= 0 && ticket_20 <= 0) {
+            ticketRolls = tempList;
+        } else {
             break;
         }
         // eslint-disable-next-line no-constant-condition
@@ -252,35 +315,39 @@ export async function pickNormal(message: Message) {
     const createTables = t.map((g) => {
         return {
             user_id: message.author.id,
-            gachaTime: nowTime,
+            item_id: g.item_id,
+            pick_date: nowTime,
             rare: g.rare,
             rank: g.rank,
-            description: g.description
+            is_used: 0
         };
     });
 
     await gachaTable.save(createTables);
+
+    const itemRepository = new ItemRepository();
+    const items = await itemRepository.getAll();
 
     await users.save({
         id: message.author.id,
         user_name: message.author.tag,
         last_pick_date: dayjs().toDate()
     });
-    const presents = t.filter((g) => g.description.includes('_**プレゼント**_'));
-    const desc = t.map((g) => `[${g.rare}] ` + g.description).join('\n');
+    const presents = t.filter((g) => items.find((i) => i.id === g.item_id)?.is_present === 1);
+    const desc = t.map((g) => `[${g.rare}]${g.icon ? g.icon : ''} ${g.name}`).join('\n');
 
     if (t.length > 99) {
         const send = new EmbedBuilder()
             .setColor('#ff9900')
             .setTitle(`${gachaList.length}連の結果: 高い順に50要素のみ抜き出しています`)
-            .setDescription(`${highTier.map((g) => `[${g.rare}] ` + g.description).join('\n')}`)
+            .setDescription(`${highTier.map((g) => `[${g.rare}]${g.icon ? g.icon : ''} ${g.name}`).join('\n')}`)
             .setThumbnail('https://s3-ap-northeast-1.amazonaws.com/rim.public-upload/pic/gacha.png');
         message.reply({ content: `ガチャだよ！からんころーん！(景品は一日の最初の一回のみです)`, embeds: [send] });
         if (presents.length > 0) {
             const send = new EmbedBuilder()
                 .setColor('#ff9900')
                 .setTitle('プレゼントだ～！おめでと～！！')
-                .setDescription(presents.map((p) => `${p.rare}: ${p.description}`).join('\n'))
+                .setDescription(presents.map((p) => `[${p.rare}] ${p.name}`).join('\n'))
                 .setFields({ name: '通知:', value: '<@246007305156558848>' });
             message.channel.send({ embeds: [send] });
         }
@@ -295,7 +362,7 @@ export async function pickNormal(message: Message) {
             const send = new EmbedBuilder()
                 .setColor('#ff9900')
                 .setTitle('プレゼントだ～！おめでと～！！')
-                .setDescription(presents.map((p) => `${p.rare}: ${p.description}`).join('\n'))
+                .setDescription(presents.map((p) => `[${p.rare}] ${p.name}`).join('\n'))
                 .setFields({ name: '通知用:', value: '<@246007305156558848>' });
             message.channel.send({ embeds: [send] });
         }
@@ -446,9 +513,13 @@ function getOmikujiOnce(): Omikuji {
 }
 
 export interface Gacha {
+    item_id: number;
+    name: string;
+    icon: string | null;
     rare: string;
-    description: string;
     rank: number;
+    is_present: boolean;
+    reroll: number;
 }
 
 export interface Omikuji {

--- a/src/bot/function/register.ts
+++ b/src/bot/function/register.ts
@@ -17,7 +17,7 @@ export async function save(message: Message, args?: string[]): Promise<void> {
             const users = new UsersRepository();
             await users.save({
                 id: userId,
-                userName: message.author.tag,
+                user_name: message.author.tag,
                 pref: regName[0]
             });
 

--- a/src/constant/constants.ts
+++ b/src/constant/constants.ts
@@ -17,3 +17,12 @@ export const DISCORD_CLIENT = new Client({
 });
 
 export const EXCLUDE_ROOM = ['ロビー', '墓'];
+
+export const ICON = {
+    CROWN: ':crown:',
+    SPARKLES: ':sparkles:',
+    STAR: ':star:',
+    STAR2: ':star2:',
+    TICKETS: ':tickets:',
+    HEART: ':heart:'
+};

--- a/src/constant/gacha/gachaList.ts
+++ b/src/constant/gacha/gachaList.ts
@@ -2,69 +2,343 @@
  * ガチャ品
  */
 
-export const GACHA_MONEY_LIST = {
-    UUR: [
-        '_**プレゼント**_ プレミアムお食事券(PayPay or Steamギフト券10,000円分)',
-        '_**プレゼント**_ プレミアムお食事券(PayPay or Steamギフト券5,000円分)',
-        '_**プレゼント**_ プレミアムお食事券(PayPay or Steamギフト券5,000円分)',
-        '_**プレゼント**_ プレミアムお食事券(PayPay or Steamギフト券5,000円分)',
-        '_**プレゼント**_ プレミアムお食事券(PayPay or Steamギフト券3,000円分)',
-        '_**プレゼント**_ プレミアムお食事券(PayPay or Steamギフト券3,000円分)',
-        '_**プレゼント**_ プレミアムお食事券(PayPay or Steamギフト券3,000円分)',
-        '_**プレゼント**_ プレミアムお食事券(PayPay or Steamギフト券3,000円分)',
-        '_**プレゼント**_ プレミアムお食事券(PayPay or Steamギフト券3,000円分)',
-        '_**プレゼント**_ プレミアムお食事券(PayPay or Steamギフト券3,000円分)'
-    ],
-    UR: [
-        '封印されしりむの右腕',
-        '封印されしりむの右腕',
-        '_**プレゼント**_ プレミアムお食事券(PayPay or Steamギフト券500円分)',
-        '_**プレゼント**_ プレミアムお食事券(PayPay or Steamギフト券500円分)',
-        '_**プレゼント**_ プレミアムお食事券(PayPay or Steamギフト券1,000円分)',
-        '_**プレゼント**_ プレミアムお食事券(PayPay or Steamギフト券1,000円分)',
-        '_**プレゼント**_ プレミアムお食事券(PayPay or Steamギフト券1,500円分)',
-        '_**プレゼント**_ プレミアムお食事券(PayPay or Steamギフト券2,000円分)'
-    ],
-    SSR: [
-        'ガチャ+20連チケット',
-        'ガチャ+20連チケット',
-        'ガチャ+20連チケット',
-        '初音ミクフィギュア',
-        '初音ミクフィギュア',
-        'りむの無くしたメガネ',
-        '壊れたジョイコン3点セット',
-        '壊れたジョイコン3点セット',
-        'とんこつラーメン+半チャーハンセット',
-        'とんこつラーメン+半チャーハンセット',
-        'もぎもぎフルーツグミ',
-        '飲むフルーツゼリー',
-        'ノイズキャンセリングイヤホン',
-        'めあの写真',
-        '_**プレゼント**_ みかんちゃんに対応ワード追加券'
-    ],
-    SR: [
-        'ガチャ+10連チケット',
-        '棘竜の天鱗',
-        '火竜の紅玉',
-        '黒蝕竜の天鱗',
-        '斬竜の天鱗',
-        'ゲーミングノートPC',
-        'ごはん200g',
-        '黒烏龍茶1,000ml'
-    ],
-    R: [
-        '塩タン1人前',
-        'カルビ1人前',
-        'ハラミ1人前',
-        'コカ・コーラ 500ml',
-        'アクエリアス 500ml',
-        'ハチノス1人前',
-        'ハツ1人前',
-        'ミノ1人前',
-        'ホルモン1人前',
-        '七味唐辛子',
-        'たまねぎスープ'
-    ],
-    UC: ['温州みかん', '龍の髭', '唐辛子', '烏龍茶 500ml', 'チキンナゲット', 'たまごスープ'],
-    C: ['綿棒', '鼻がかゆくなるマスク', 'ダンボール', '水素水', 'お吸いもの']
-};
+import { ICON } from '../constants';
+
+export const GACHA_LIST = [
+    {
+        rare: 'UUR',
+        icon: ICON.CROWN,
+        name: 'プレミアムお食事券(PayPay or Steamギフト券10,000円分)',
+        is_present: 1,
+        weight: 1
+    },
+    {
+        rare: 'UUR',
+        icon: ICON.CROWN,
+        name: 'プレミアムお食事券(PayPay or Steamギフト券5,000円分)',
+        is_present: 1,
+        weight: 4
+    },
+    {
+        rare: 'UUR',
+        icon: ICON.CROWN,
+        name: 'プレミアムお食事券(PayPay or Steamギフト券3,000円分)',
+        is_present: 1,
+        weight: 5
+    },
+    {
+        rare: 'UR',
+        icon: ICON.SPARKLES,
+        name: 'みかんちゃんに対応ワード追加券',
+        is_present: 1,
+        weight: 3
+    },
+    {
+        rare: 'UR',
+        icon: ICON.SPARKLES,
+        name: '封印されしりむの右腕',
+        is_present: 0,
+        weight: 3
+    },
+    {
+        rare: 'UR',
+        icon: ICON.SPARKLES,
+        name: 'プレミアムお食事券(PayPay or Steamギフト券500円分)',
+        is_present: 1,
+        weight: 5
+    },
+    {
+        rare: 'UR',
+        icon: ICON.SPARKLES,
+        name: 'プレミアムお食事券(PayPay or Steamギフト券1,000円分)',
+        is_present: 1,
+        weight: 3
+    },
+    {
+        rare: 'UR',
+        icon: ICON.SPARKLES,
+        name: 'プレミアムお食事券(PayPay or Steamギフト券1,500円分)',
+        is_present: 1,
+        weight: 2
+    },
+    {
+        rare: 'UR',
+        icon: ICON.SPARKLES,
+        name: 'プレミアムお食事券(PayPay or Steamギフト券2,000円分)',
+        is_present: 1,
+        weight: 1
+    },
+    {
+        rare: 'SSR',
+        icon: ICON.STAR + ICON.TICKETS,
+        name: 'ガチャ+20連チケット',
+        is_present: 0,
+        reroll: 20,
+        weight: 8
+    },
+    {
+        rare: 'SSR',
+        icon: ICON.STAR,
+        name: '初音ミクフィギュア',
+        is_present: 0,
+        weight: 2
+    },
+    {
+        rare: 'SSR',
+        icon: ICON.STAR,
+        name: '鏡音リンフィギュア',
+        is_present: 0,
+        weight: 2
+    },
+    {
+        rare: 'SSR',
+        icon: ICON.STAR,
+        name: '鏡音レンフィギュア',
+        is_present: 0,
+        weight: 2
+    },
+    {
+        rare: 'SSR',
+        icon: ICON.STAR,
+        name: '巡音ルカフィギュア',
+        is_present: 0,
+        weight: 2
+    },
+    {
+        rare: 'SSR',
+        icon: ICON.STAR,
+        name: 'りむの無くしたメガネ',
+        is_present: 0,
+        weight: 1
+    },
+    {
+        rare: 'SSR',
+        icon: ICON.STAR,
+        name: '壊れたジョイコン3点セット',
+        is_present: 0,
+        weight: 1
+    },
+    {
+        rare: 'SSR',
+        icon: ICON.STAR,
+        name: 'とんこつラーメン+半チャーハンセット',
+        is_present: 0,
+        weight: 2
+    },
+    {
+        rare: 'SSR',
+        icon: ICON.STAR,
+        name: 'もぎもぎフルーツグミ',
+        is_present: 0,
+        weight: 1
+    },
+    {
+        rare: 'SSR',
+        icon: ICON.STAR,
+        name: '飲むフルーツゼリー',
+        is_present: 0,
+        weight: 1
+    },
+    {
+        rare: 'SSR',
+        icon: ICON.STAR,
+        name: 'ノイズキャンセリングイヤホン',
+        is_present: 0,
+        weight: 1
+    },
+    {
+        rare: 'SSR',
+        icon: ICON.STAR,
+        name: 'めあの写真',
+        is_present: 0,
+        weight: 3
+    },
+    {
+        rare: 'SR',
+        icon: ICON.TICKETS,
+        name: 'ガチャ+10連チケット',
+        is_present: 0,
+        reroll: 10,
+        weight: 5
+    },
+    {
+        rare: 'SR',
+        name: '棘竜の天鱗',
+        is_present: 0,
+        weight: 1
+    },
+    {
+        rare: 'SR',
+        name: '火竜の紅玉',
+        is_present: 0,
+        weight: 1
+    },
+    {
+        rare: 'SR',
+        name: '黒蝕竜の天鱗',
+        is_present: 0,
+        weight: 1
+    },
+    {
+        rare: 'SR',
+        name: '斬竜の天鱗',
+        is_present: 0,
+        weight: 1
+    },
+    {
+        rare: 'SR',
+        name: 'ゲーミングノートPC',
+        is_present: 0,
+        weight: 1
+    },
+    {
+        rare: 'SR',
+        name: 'ごはん200g',
+        is_present: 0,
+        weight: 1
+    },
+    {
+        rare: 'SR',
+        name: '黒烏龍茶1,000ml',
+        is_present: 0,
+        weight: 1
+    },
+    {
+        rare: 'R',
+        name: '塩タン1人前',
+        is_present: 0,
+        weight: 1
+    },
+    {
+        rare: 'R',
+        name: 'カルビ1人前',
+        is_present: 0,
+        weight: 1
+    },
+    {
+        rare: 'R',
+        name: 'ハンバーグ1人前',
+        is_present: 0,
+        weight: 1
+    },
+    {
+        rare: 'R',
+        name: 'ハラミ1人前',
+        is_present: 0,
+        weight: 1
+    },
+    {
+        rare: 'R',
+        name: 'コカ・コーラ 500ml',
+        is_present: 0,
+        weight: 1
+    },
+    {
+        rare: 'R',
+        name: 'アクエリアス 500ml',
+        is_present: 0,
+        weight: 1
+    },
+    {
+        rare: 'R',
+        name: 'ハチノス1人前',
+        is_present: 0,
+        weight: 1
+    },
+    {
+        rare: 'R',
+        name: 'ハツ1人前',
+        is_present: 0,
+        weight: 1
+    },
+    {
+        rare: 'R',
+        name: 'ミノ1人前',
+        is_present: 0,
+        weight: 1
+    },
+    {
+        rare: 'R',
+        name: 'ホルモン1人前',
+        is_present: 0,
+        weight: 1
+    },
+    {
+        rare: 'R',
+        name: '七味唐辛子',
+        is_present: 0,
+        weight: 1
+    },
+    {
+        rare: 'R',
+        name: 'たまねぎスープ',
+        is_present: 0,
+        weight: 1
+    },
+    {
+        rare: 'UC',
+        name: '温州みかん',
+        is_present: 0,
+        weight: 1
+    },
+    {
+        rare: 'UC',
+        name: '龍の髭',
+        is_present: 0,
+        weight: 1
+    },
+    {
+        rare: 'UC',
+        name: '唐辛子',
+        is_present: 0,
+        weight: 1
+    },
+    {
+        rare: 'UC',
+        name: '烏龍茶 500ml',
+        is_present: 0,
+        weight: 1
+    },
+    {
+        rare: 'UC',
+        name: 'チキンナゲット',
+        is_present: 0,
+        weight: 1
+    },
+    {
+        rare: 'UC',
+        name: 'たまごスープ',
+        is_present: 0,
+        weight: 1
+    },
+    {
+        rare: 'C',
+        name: '綿棒',
+        is_present: 0,
+        weight: 1
+    },
+    {
+        rare: 'C',
+        name: '鼻がかゆくなるマスク',
+        is_present: 0,
+        weight: 1
+    },
+    {
+        rare: 'C',
+        name: 'ダンボール',
+        is_present: 0,
+        weight: 1
+    },
+    {
+        rare: 'C',
+        name: '水素水',
+        is_present: 0,
+        weight: 1
+    },
+    {
+        rare: 'C',
+        name: 'お吸いもの',
+        is_present: 0,
+        weight: 1
+    }
+];

--- a/src/controller/gachaRouter.ts
+++ b/src/controller/gachaRouter.ts
@@ -34,6 +34,6 @@ gachaRouter.get('/gacha', async (req: Express.Request, res: Express.Response) =>
         return;
     }
 
-    const gacha = await repository.get(uid, date, limit);
+    const gacha = await repository.getHistory(uid, date, limit);
     res.status(200).send(gacha);
 });

--- a/src/model/models/gacha.ts
+++ b/src/model/models/gacha.ts
@@ -9,10 +9,10 @@ import {
     PrimaryGeneratedColumn
 } from 'typeorm';
 import { Users } from './users';
-import { ItemTable } from './item';
+import { Item } from './item';
 
 @Entity({ engine: 'InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci' })
-export class GachaTable extends BaseEntity {
+export class Gacha extends BaseEntity {
     @PrimaryGeneratedColumn()
     id!: number;
 
@@ -29,16 +29,16 @@ export class GachaTable extends BaseEntity {
     is_used!: number;
 
     @DeleteDateColumn({ type: 'datetime', nullable: true })
-    deleted_at?: Date;
+    deleted_at: Date | null = null;
 
     @CreateDateColumn({ type: 'datetime', nullable: false })
     created_at!: Date;
 
     @ManyToOne(() => Users, (user) => user.id)
-    @JoinColumn({ name: 'user_id' })
+    @JoinColumn({ name: 'user_id', referencedColumnName: 'id' })
     users!: Users;
 
-    @ManyToOne(() => ItemTable, (item) => item.id)
-    @JoinColumn({ name: 'item_id' })
-    items!: ItemTable;
+    @ManyToOne(() => Item, (item) => item.id)
+    @JoinColumn({ name: 'item_id', referencedColumnName: 'id' })
+    items!: Item;
 }

--- a/src/model/models/gacha.ts
+++ b/src/model/models/gacha.ts
@@ -9,34 +9,36 @@ import {
     PrimaryGeneratedColumn
 } from 'typeorm';
 import { Users } from './users';
+import { ItemTable } from './item';
 
 @Entity({ engine: 'InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci' })
 export class GachaTable extends BaseEntity {
     @PrimaryGeneratedColumn()
-    id!: string;
+    id!: number;
 
     @Column({ type: 'bigint', width: 20 })
     user_id!: string;
 
+    @Column({ type: 'bigint' })
+    item_id!: number;
+
     @Column({ type: 'datetime', nullable: false })
-    gachaTime!: Date;
+    pick_date!: Date;
 
-    @Column({ type: 'varchar', width: 255, nullable: false })
-    rare!: string;
-
-    @Column({ type: 'tinyint', nullable: false })
-    rank!: number;
-
-    @Column({ type: 'varchar', width: 255, nullable: false })
-    description!: string;
+    @Column({ type: 'tinyint', nullable: false, default: 0 })
+    is_used!: number;
 
     @DeleteDateColumn({ type: 'datetime', nullable: true })
-    deletedAt?: Date;
+    deleted_at?: Date;
 
     @CreateDateColumn({ type: 'datetime', nullable: false })
-    createdAt!: Date;
+    created_at!: Date;
 
     @ManyToOne(() => Users, (user) => user.id)
     @JoinColumn({ name: 'user_id' })
     users!: Users;
+
+    @ManyToOne(() => ItemTable, (item) => item.id)
+    @JoinColumn({ name: 'item_id' })
+    items!: ItemTable;
 }

--- a/src/model/models/guild.ts
+++ b/src/model/models/guild.ts
@@ -17,23 +17,23 @@ export class Guild extends BaseEntity {
     name!: string;
 
     @Column({ type: 'varchar', width: 255, default: 'ロビー' })
-    lobbyName!: string;
+    lobby_name!: string;
 
     @Column({ type: 'varchar', width: 255, default: '墓' })
-    inactiveName!: string;
+    inactive_name!: string;
 
     @Column({ type: 'varchar', width: 255, nullable: true })
-    excludeNames!: string | null;
+    exclude_names?: string;
 
     @Column({ type: 'tinyint', default: 0 })
     silent!: number;
 
     @DeleteDateColumn({ type: 'datetime', nullable: true })
-    deletedAt!: Date | null;
+    deleted_at!: Date | null;
 
     @UpdateDateColumn({ type: 'datetime', nullable: true })
-    updatedAt!: Date | null;
+    updated_at!: Date | null;
 
     @CreateDateColumn({ type: 'datetime', nullable: false })
-    createdAt!: Date;
+    created_at!: Date;
 }

--- a/src/model/models/guild.ts
+++ b/src/model/models/guild.ts
@@ -23,16 +23,16 @@ export class Guild extends BaseEntity {
     inactive_name!: string;
 
     @Column({ type: 'varchar', width: 255, nullable: true })
-    exclude_names?: string;
+    exclude_names: string | null = null;
 
     @Column({ type: 'tinyint', default: 0 })
     silent!: number;
 
     @DeleteDateColumn({ type: 'datetime', nullable: true })
-    deleted_at!: Date | null;
+    deleted_at: Date | null = null;
 
     @UpdateDateColumn({ type: 'datetime', nullable: true })
-    updated_at!: Date | null;
+    updated_at: Date | null = null;
 
     @CreateDateColumn({ type: 'datetime', nullable: false })
     created_at!: Date;

--- a/src/model/models/index.ts
+++ b/src/model/models/index.ts
@@ -1,6 +1,7 @@
 export { Music } from './music';
-export { GachaTable } from './gacha';
+export { GachaTable as Gacha } from './gacha';
 export { MusicInfo } from './musicInfo';
 export { Users } from './users';
 export { Playlist } from './playlist';
 export { Guild } from './guild';
+export { ItemTable as Item } from './item';

--- a/src/model/models/index.ts
+++ b/src/model/models/index.ts
@@ -1,7 +1,8 @@
 export { Music } from './music';
-export { GachaTable as Gacha } from './gacha';
+export { Gacha } from './gacha';
 export { MusicInfo } from './musicInfo';
 export { Users } from './users';
 export { Playlist } from './playlist';
 export { Guild } from './guild';
-export { ItemTable as Item } from './item';
+export { Item } from './item';
+export { ItemRank } from './itemRank';

--- a/src/model/models/item.ts
+++ b/src/model/models/item.ts
@@ -4,34 +4,50 @@ import {
     CreateDateColumn,
     DeleteDateColumn,
     Entity,
+    JoinColumn,
+    ManyToOne,
     OneToMany,
     PrimaryGeneratedColumn
 } from 'typeorm';
-import { GachaTable } from './gacha';
+import { Gacha } from './gacha';
+import { ItemRank } from './itemRank';
 
 @Entity({ engine: 'InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci' })
-export class ItemTable extends BaseEntity {
+export class Item extends BaseEntity {
     @PrimaryGeneratedColumn({ type: 'bigint' })
     id!: number;
 
     @Column({ type: 'varchar', length: 255, nullable: false })
     name!: string;
 
+    @Column({ type: 'varchar', length: 255, nullable: true })
+    icon: string | null = null;
+
     @Column({ type: 'varchar', length: 255, nullable: false })
     rare!: string;
 
     @Column({ type: 'varchar', length: 255, nullable: true })
-    description?: string;
+    description: string | null = null;
+
+    @Column({ type: 'smallint', default: 1, nullable: false })
+    weight!: number;
 
     @Column({ type: 'tinyint', default: 0, nullable: false })
     is_present!: number;
 
+    @Column({ type: 'smallint', default: 0, nullable: false })
+    reroll!: number;
+
     @DeleteDateColumn({ type: 'datetime', nullable: true })
-    deleted_at?: Date;
+    deleted_at: Date | null = null;
 
     @CreateDateColumn({ type: 'datetime', nullable: false })
     created_at!: Date;
 
-    @OneToMany(() => GachaTable, (g) => g.item_id)
-    gacha?: GachaTable[];
+    @OneToMany(() => Gacha, (g) => g.item_id)
+    gacha?: Gacha[];
+
+    @ManyToOne(() => ItemRank, (item) => item.rare)
+    @JoinColumn({ name: 'rare', referencedColumnName: 'rare' })
+    item_rank!: ItemRank;
 }

--- a/src/model/models/item.ts
+++ b/src/model/models/item.ts
@@ -1,0 +1,37 @@
+import {
+    BaseEntity,
+    Column,
+    CreateDateColumn,
+    DeleteDateColumn,
+    Entity,
+    OneToMany,
+    PrimaryGeneratedColumn
+} from 'typeorm';
+import { GachaTable } from './gacha';
+
+@Entity({ engine: 'InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci' })
+export class ItemTable extends BaseEntity {
+    @PrimaryGeneratedColumn({ type: 'bigint' })
+    id!: number;
+
+    @Column({ type: 'varchar', length: 255, nullable: false })
+    name!: string;
+
+    @Column({ type: 'varchar', length: 255, nullable: false })
+    rare!: string;
+
+    @Column({ type: 'varchar', length: 255, nullable: true })
+    description?: string;
+
+    @Column({ type: 'tinyint', default: 0, nullable: false })
+    is_present!: number;
+
+    @DeleteDateColumn({ type: 'datetime', nullable: true })
+    deleted_at?: Date;
+
+    @CreateDateColumn({ type: 'datetime', nullable: false })
+    created_at!: Date;
+
+    @OneToMany(() => GachaTable, (g) => g.item_id)
+    gacha?: GachaTable[];
+}

--- a/src/model/models/itemRank.ts
+++ b/src/model/models/itemRank.ts
@@ -1,0 +1,35 @@
+import {
+    BaseEntity,
+    Column,
+    CreateDateColumn,
+    DeleteDateColumn,
+    Entity,
+    JoinColumn,
+    JoinTable,
+    OneToMany,
+    PrimaryGeneratedColumn
+} from 'typeorm';
+import { Item } from './item';
+
+@Entity({ engine: 'InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci' })
+export class ItemRank extends BaseEntity {
+    @PrimaryGeneratedColumn({ type: 'bigint' })
+    id!: number;
+
+    @Column({ type: 'varchar', length: 255, nullable: false, unique: true })
+    rare!: RARE;
+
+    @Column({ type: 'smallint', nullable: false })
+    rank!: number;
+
+    @DeleteDateColumn({ type: 'datetime', nullable: true })
+    deleted_at: Date | null = null;
+
+    @CreateDateColumn({ type: 'datetime', nullable: false })
+    created_at!: Date;
+
+    @OneToMany(() => Item, (item) => item.rare)
+    items!: Item[];
+}
+
+type RARE = 'UUR' | 'UR' | 'SSR' | 'SR' | 'R' | 'UC' | 'C';

--- a/src/model/models/music.ts
+++ b/src/model/models/music.ts
@@ -21,5 +21,5 @@ export class Music extends BaseEntity {
     is_play!: number;
 
     @CreateDateColumn({ type: 'datetime', nullable: false })
-    createdAt!: Date;
+    created_at!: Date;
 }

--- a/src/model/models/musicInfo.ts
+++ b/src/model/models/musicInfo.ts
@@ -12,13 +12,13 @@ export class MusicInfo extends BaseEntity {
     is_loop!: number;
 
     @Column({ type: 'varchar', width: 255, nullable: true })
-    title!: string | null;
+    title: string | null = null;
 
     @Column({ type: 'varchar', width: 255, nullable: true })
-    url!: string | null;
+    url: string | null = null;
 
     @Column({ type: 'varchar', width: 255, nullable: true })
-    thumbnail!: string | null;
+    thumbnail: string | null = null;
 
     @Column({ type: 'tinyint', nullable: false, default: 0 })
     silent!: number;

--- a/src/model/models/musicInfo.ts
+++ b/src/model/models/musicInfo.ts
@@ -24,5 +24,5 @@ export class MusicInfo extends BaseEntity {
     silent!: number;
 
     @CreateDateColumn({ type: 'datetime', nullable: false })
-    createdAt!: Date;
+    created_at!: Date;
 }

--- a/src/model/models/playlist.ts
+++ b/src/model/models/playlist.ts
@@ -24,5 +24,5 @@ export class Playlist extends BaseEntity {
     loop!: number;
 
     @CreateDateColumn({ type: 'datetime', nullable: false })
-    createdAt!: Date;
+    created_at!: Date;
 }

--- a/src/model/models/users.ts
+++ b/src/model/models/users.ts
@@ -8,7 +8,7 @@ import {
     PrimaryColumn,
     UpdateDateColumn
 } from 'typeorm';
-import { GachaTable } from './gacha';
+import { Gacha } from './gacha';
 
 @Entity({ engine: 'InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci' })
 export class Users extends BaseEntity {
@@ -16,23 +16,23 @@ export class Users extends BaseEntity {
     id!: string;
 
     @Column({ type: 'varchar', width: 255, nullable: true })
-    user_name!: string | null;
+    user_name: string | null = null;
 
     @Column({ type: 'varchar', width: 255, nullable: true })
-    pref!: string | null;
+    pref: string | null = null;
 
     @Column({ type: 'datetime', nullable: true })
-    last_pick_date!: Date | null;
+    last_pick_date: Date | null = null;
 
     @DeleteDateColumn({ type: 'datetime', nullable: true })
-    deleted_at!: Date | null;
+    deleted_at: Date | null = null;
 
     @UpdateDateColumn({ type: 'datetime', nullable: true })
-    updated_at!: Date | null;
+    updated_at: Date | null = null;
 
     @CreateDateColumn({ type: 'datetime', nullable: false })
     created_at!: Date;
 
-    @OneToMany(() => GachaTable, (g) => g.user_id)
-    gacha?: GachaTable[];
+    @OneToMany(() => Gacha, (g) => g.user_id)
+    gacha?: Gacha[];
 }

--- a/src/model/models/users.ts
+++ b/src/model/models/users.ts
@@ -16,22 +16,22 @@ export class Users extends BaseEntity {
     id!: string;
 
     @Column({ type: 'varchar', width: 255, nullable: true })
-    userName!: string | null;
+    user_name!: string | null;
 
     @Column({ type: 'varchar', width: 255, nullable: true })
     pref!: string | null;
 
     @Column({ type: 'datetime', nullable: true })
-    gachaDate!: Date | null;
+    last_pick_date!: Date | null;
 
     @DeleteDateColumn({ type: 'datetime', nullable: true })
-    deletedAt!: Date | null;
+    deleted_at!: Date | null;
 
     @UpdateDateColumn({ type: 'datetime', nullable: true })
-    updatedAt!: Date | null;
+    updated_at!: Date | null;
 
     @CreateDateColumn({ type: 'datetime', nullable: false })
-    createdAt!: Date;
+    created_at!: Date;
 
     @OneToMany(() => GachaTable, (g) => g.user_id)
     gacha?: GachaTable[];

--- a/src/model/repository/gachaRepository.ts
+++ b/src/model/repository/gachaRepository.ts
@@ -1,12 +1,12 @@
-import { DeepPartial, Repository } from 'typeorm';
+import { DeepPartial, Like, MoreThanOrEqual, Repository } from 'typeorm';
 import * as Models from '../models';
 import { TypeOrm } from '../typeorm/typeorm';
 
 export class GachaRepository {
-    private repository: Repository<Models.GachaTable>;
+    private repository: Repository<Models.Gacha>;
 
     constructor() {
-        this.repository = TypeOrm.dataSource.getRepository(Models.GachaTable);
+        this.repository = TypeOrm.dataSource.getRepository(Models.Gacha);
     }
 
     /**
@@ -16,26 +16,53 @@ export class GachaRepository {
      * @param limit limit
      * @returns Promise<GachaTable[] | null>
      */
-    public async get(uid: string, date?: Date, limit?: number): Promise<Models.GachaTable[] | null> {
-        const gacha = this.repository.createQueryBuilder();
-        gacha.where('user_id = :id', { id: uid });
-
+    public async getHistory(uid: string, date?: Date, limit?: number): Promise<Models.Gacha[] | null> {
         if (date) {
-            gacha.andWhere('gachaTime >= :date', { date: date });
+            return await this.repository.find({
+                relations: ['item'],
+                where: { user_id: uid, pick_date: MoreThanOrEqual(date) },
+                order: { pick_date: 'DESC' },
+                take: limit ? limit : 100
+            });
         }
 
-        gacha.orderBy('gachaTime', 'DESC');
-
-        gacha.limit(limit ? limit : 100);
-
-        return (await gacha.getMany()) as Models.GachaTable[];
+        return await this.repository.find({
+            relations: ['item'],
+            where: { user_id: uid },
+            order: { pick_date: 'DESC' },
+            take: limit ? limit : 100
+        });
     }
 
     /**
      * 引いたガチャを保存する
      * @param gacha
      */
-    public async save(gacha: DeepPartial<Models.GachaTable>[]): Promise<void> {
+    public async save(gacha: DeepPartial<Models.Gacha>[]): Promise<void> {
         await this.repository.save(gacha);
+    }
+
+    /**
+     * プレゼントを取得する
+     * @param uid ユーザID
+     * @returns Gacha[]
+     */
+    public async getPresents(uid: string): Promise<Models.Gacha[]> {
+        const gachaList = await this.repository.find({
+            where: { user_id: uid, items: { is_present: 1 }, is_used: 0 }
+        });
+        return gachaList;
+    }
+
+    /**
+     * プレゼントを使用する
+     * @param id ガチャID
+     */
+    public async usePresent(id: number): Promise<void> {
+        const gacha = await this.repository.findOne({ where: { id: id } });
+        if (gacha) {
+            gacha.is_used = 1;
+            await this.repository.save(gacha);
+        }
     }
 }

--- a/src/model/repository/gachaRepository.ts
+++ b/src/model/repository/gachaRepository.ts
@@ -49,6 +49,9 @@ export class GachaRepository {
      */
     public async getPresents(uid: string): Promise<Models.Gacha[]> {
         const gachaList = await this.repository.find({
+            relations: {
+                items: true
+            },
             where: { user_id: uid, items: { is_present: 1 }, is_used: 0 }
         });
         return gachaList;

--- a/src/model/repository/itemRepository.ts
+++ b/src/model/repository/itemRepository.ts
@@ -1,0 +1,31 @@
+import { DeepPartial, Repository } from 'typeorm';
+import * as Models from '../models';
+import { TypeOrm } from '../typeorm/typeorm';
+
+export class ItemRepository {
+    private repository: Repository<Models.Item>;
+
+    constructor() {
+        this.repository = TypeOrm.dataSource.getRepository(Models.Item);
+    }
+
+    /**
+     * アイテムを取得する
+     * @param rare レア度
+     * @returns Promise<ItemTable[] | null>
+     */
+    public async get(rare: string): Promise<Models.Item[]> {
+        return await this.repository.find({
+            where: { rare: rare }
+        });
+    }
+
+    /**
+     * アイテムを登録する
+     * @param item
+     * @returns
+     */
+    public async save(item: DeepPartial<Models.Item>): Promise<void> {
+        await this.repository.save(item);
+    }
+}

--- a/src/model/repository/usersRepository.ts
+++ b/src/model/repository/usersRepository.ts
@@ -33,6 +33,6 @@ export class UsersRepository {
      * @param uid user id
      */
     public async resetGacha(uid: string): Promise<void> {
-        await this.repository.save({ id: uid, gachaDate: null });
+        await this.repository.save({ id: uid, last_pick_date: null });
     }
 }

--- a/src/model/typeorm/typeorm.ts
+++ b/src/model/typeorm/typeorm.ts
@@ -21,7 +21,8 @@ export class TypeOrm {
             Models.MusicInfo,
             Models.Playlist,
             Models.Item,
-            Models.Guild
+            Models.Guild,
+            Models.ItemRank
         ] // 利用するエンティティ。パスでの指定も可能
     });
 }

--- a/src/model/typeorm/typeorm.ts
+++ b/src/model/typeorm/typeorm.ts
@@ -14,6 +14,14 @@ export class TypeOrm {
         synchronize: true, // DBとのスキーマ同期(開発用)
         dropSchema: false, // スキーマ削除(開発用)
         charset: 'utf8mb4',
-        entities: [Models.Users, Models.GachaTable, Models.Music, Models.MusicInfo, Models.Playlist] // 利用するエンティティ。パスでの指定も可能
+        entities: [
+            Models.Users,
+            Models.Gacha,
+            Models.Music,
+            Models.MusicInfo,
+            Models.Playlist,
+            Models.Item,
+            Models.Guild
+        ] // 利用するエンティティ。パスでの指定も可能
     });
 }


### PR DESCRIPTION
# 実装
- プレゼントの数を取得したいが今のテーブル構造だと面倒なのでテーブル構造を変更する

# 構造
- gacha_table
  - 命名規則を統一, スネークケースに
  - rare, rank, description削除
  - gachaTime から pick_date にカラム名変更

- item_table
  - 新規作成
  - データ構造は[該当コミット](https://github.com/Rim-Earthlights/ts-orangebot/blob/feature/refactor-gacha-table/src/model/models/item.ts)を参照
  
- 構造変更に伴うガチャ系の実装修正