### PR TITLE
ガチャをチケット分を除いて10連ずつ引くように変更

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -16,6 +16,7 @@ import * as logger from './common/logger';
 import { ItemRepository } from './model/repository/itemRepository';
 import { GACHA_LIST } from './constant/gacha/gachaList';
 import { Gacha } from './bot/function';
+import { initJob } from './job/job';
 
 dotenv.config();
 
@@ -103,6 +104,7 @@ DISCORD_CLIENT.once('ready', async () => {
         .catch((e) => {
             logger.error('system', 'db-init', e);
         });
+    await initJob();
     logger.info(undefined, 'ready', `discord bot logged in: ${DISCORD_CLIENT.user?.tag}`);
 });
 

--- a/src/job/job.ts
+++ b/src/job/job.ts
@@ -1,0 +1,15 @@
+import * as cron from 'node-cron';
+import * as logger from '../common/logger';
+import { UsersRepository } from '../model/repository/usersRepository';
+
+export async function initJob() {
+    /**
+     * 毎日0時に実行されるタスク
+     */
+    cron.schedule('0 0 * * *', async () => {
+        logger.info(undefined, 'Cron job: 0 0 * * *');
+        const user = new UsersRepository();
+        await user.addPickLeft();
+    });
+    logger.info(undefined, 'Cron job', 'Initialized');
+}

--- a/src/model/models/users.ts
+++ b/src/model/models/users.ts
@@ -24,6 +24,9 @@ export class Users extends BaseEntity {
     @Column({ type: 'datetime', nullable: true })
     last_pick_date: Date | null = null;
 
+    @Column({ type: 'int', nullable: false, default: 0 })
+    pick_left!: number;
+
     @DeleteDateColumn({ type: 'datetime', nullable: true })
     deleted_at: Date | null = null;
 

--- a/src/model/repository/gachaRepository.ts
+++ b/src/model/repository/gachaRepository.ts
@@ -61,11 +61,13 @@ export class GachaRepository {
      * プレゼントを使用する
      * @param id ガチャID
      */
-    public async usePresent(id: number): Promise<void> {
+    public async usePresent(id: number): Promise<boolean> {
         const gacha = await this.repository.findOne({ where: { id: id } });
         if (gacha) {
             gacha.is_used = 1;
             await this.repository.save(gacha);
+            return true;
         }
+        return false;
     }
 }

--- a/src/model/repository/usersRepository.ts
+++ b/src/model/repository/usersRepository.ts
@@ -29,10 +29,21 @@ export class UsersRepository {
     }
 
     /**
-     * ガチャ日をリセットする
+     * ガチャ回数を10に再セットする
      * @param uid user id
      */
     public async resetGacha(uid: string): Promise<void> {
-        await this.repository.save({ id: uid, last_pick_date: null });
+        await this.repository.save({ id: uid, pick_left: 10 });
+    }
+
+    /**
+     * ユーザの残りピック数を10増やす
+     */
+    public async addPickLeft(): Promise<void> {
+        const users = await this.repository.find();
+        const saveUsers = users.map((u) => {
+            return { ...u, pick_left: u.pick_left + 10 };
+        });
+        await this.repository.save(saveUsers);
     }
 }


### PR DESCRIPTION
# 実装
# ガチャの仕様変更
- チケット分を考慮しないで10連ずつ引くように修正
- 旧仕様は`.gacha limit`で引く
- ガチャ回数の指定で指定回数のみ引けるようにした `.gacha [回数]`
- 一日のガチャ可能回数を最後に引いたガチャ日判定ではなく、cronで0時に定時実行するようにした