### PR TITLE
docs: speakパッケージ追加・youtubei.js移行・E2EE対応をドキュメントに反映

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,7 +7,8 @@ pnpm workspace により以下のパッケージで構成されています。
 ```
 packages/
 ├── bot/        # Discord Bot 本体 (Express + Discord.js)
-└── shared/     # 共有層: TypeORM エンティティ / リポジトリ / DataSource ファクトリ / 共通型 (LoggerPort, DTO)
+├── shared/     # 共有層: TypeORM エンティティ / リポジトリ / DataSource ファクトリ / 共通型 (LoggerPort, DTO)
+└── speak/      # 読み上げ Bot (VOICEVOX / COEIROINK)。bot から HTTP で呼び出される
 ```
 
 ### shared パッケージの構成
@@ -21,7 +22,38 @@ packages/shared/src/
 └── types/          # LogData / LogLevel / LoggerPort / MusicAddItem DTO
 ```
 
-bot は `@orangebot/shared` 経由でこれらにアクセスし、起動時に `createDataSource(...)` で DataSource を初期化する。`packages/bot/src/common/logger.ts` がモジュール読み込み時に `setLogger()` で自身を shared に登録するため、shared 内のリポジトリから `getLogger().put(...)` で bot 側 Logger を呼び出せる。
+bot / speak は `@orangebot/shared` 経由でこれらにアクセスし、起動時に `createDataSource(...)` で DataSource を初期化する。`packages/bot/src/common/logger.ts` がモジュール読み込み時に `setLogger()` で自身を shared に登録するため、shared 内のリポジトリから `getLogger().put(...)` で bot 側 Logger を呼び出せる。
+
+### speak パッケージの構成
+
+旧 speak-voicevox を `packages/speak` として統合した読み上げ Bot。DB 層は `@orangebot/shared` を利用する (bot と同一 DB を共有するため `synchronize: false` で接続)。インスタンスごとに別の Discord トークン / ポートを JSON 設定で渡して複数起動する (例: lemon=4100, lime=4101)。
+
+```
+packages/speak/src/
+├── app.ts                    # エントリーポイント (引数の JSON 設定を読み込み、Express + Discord Bot 起動)
+├── routers.ts                # Express ルーター集約
+├── bot/
+│   ├── commands.ts           # ドットコマンド / スラッシュコマンドのセレクタ
+│   ├── dot_function/         # chat / room / speak のビジネスロジック
+│   ├── function/             # スラッシュコマンド向けロジック
+│   └── service/              # chatService (LLM セッション) / speakService (音声合成・再生)
+├── controllers/              # speak.controller (bot から呼ばれる HTTP API)
+├── config/                   # config.template.ts (DB/OpenAI 共通) + example.json.template (インスタンス別)
+├── common/                   # logger / VOICEVOX・COEIROINK のスピーカー ID 解決
+├── constant/                 # 定数 (DISCORD_CLIENT 等)
+├── interface/                # 音声合成 API のレスポンス型
+└── job/                      # Cron ジョブ (アイドル LLM セッションの破棄)
+```
+
+bot → speak の HTTP API (`controllers/speak.controller.ts`):
+
+| メソッド | パス | 説明 |
+|---|---|---|
+| GET | `/speaker/status/:guildId` | 読み上げ Bot の使用状況を取得 |
+| POST | `/speaker/call` | ボイスチャンネルに読み上げ Bot を呼び出す |
+| POST | `/speaker/discon` | 読み上げ Bot を切断する |
+
+使用状況は shared の `SpeakerRepository` (speaker テーブル) で guild × bot ユーザー単位に管理される。音声合成は VOICEVOX (port 50021) / COEIROINK (port 50032) のローカルエンジンを HTTP で呼び出す。
 
 ## ディレクトリ構成 (`packages/bot/src`)
 
@@ -59,11 +91,12 @@ packages/bot/src/
 │   │   ├── interaction.handler.ts  # インタラクションハンドラ I/F
 │   │   └── handlers/
 │   │       ├── commands/           # ドットコマンドハンドラ (19 ファイル)
-│   │       └── interactions/       # スラッシュコマンドハンドラ (24 ファイル)
+│   │       └── interactions/       # スラッシュコマンドハンドラ (25 ファイル)
 │   │
 │   ├── request/              # 外部 API クライアント
 │   │   ├── openai.ts         # OpenAI / LiteLLM
-│   │   ├── youtube.ts        # YouTube API
+│   │   ├── innertube.ts      # youtubei.js (Innertube) — 音楽再生用ストリーム取得
+│   │   ├── youtube.ts        # YouTube Data API
 │   │   └── spotify.ts        # Spotify
 │   │
 │   ├── services/             # サービス層 (chat.service.ts は現状空)
@@ -116,6 +149,18 @@ packages/bot/src/
       → ルームが空に → 自動削除 (is_autodelete が有効の場合)
 ```
 
+### 読み上げ (TTS)
+
+```
+ユーザーが .speak / /speak を実行 (bot 側)
+  → Speak.call()
+    → SpeakerRepository で未使用の読み上げ Bot を検索
+      → 該当インスタンスへ HTTP POST /speaker/call (lemon=4100, lime=4101)
+        → speak 側がボイスチャンネルに接続し is_used を更新
+          → 以降のテキストを VOICEVOX / COEIROINK で音声合成して再生
+            → .discon / /discon で切断・解放
+```
+
 ## 設計パターン
 
 ### Handler パターン
@@ -136,14 +181,20 @@ packages/bot/src/
 | サービス | 用途 | 設定キー |
 |---|---|---|
 | OpenAI / LiteLLM | AI チャット (複数モデル対応) | `OPENAI.KEY`, `OPENAI.BASE_URL` |
+| YouTube (Innertube / youtubei.js) | 音楽再生のストリーム取得・検索 | `YOUTUBE.COOKIE` (ログイン Cookie, 任意) |
 | YouTube Data API | プレイリスト取得・検索 | `YOUTUBE.KEY` |
 | OpenWeatherMap | 天気予報 | `FORECAST.KEY` |
 | Spotify | 歌詞連携・OAuth | Spotify OAuth 設定 |
-| VOICEVOX | テキスト読み上げ | TTS Bot 経由 |
+| VOICEVOX / COEIROINK | テキスト読み上げ (音声合成) | speak パッケージがローカルエンジン (50021 / 50032) を直接呼び出し |
+
+## ボイスチャンネルの E2EE (DAVE)
+
+Discord のボイスチャンネル E2EE (DAVE プロトコル) には `@discordjs/voice` v0.19 + `@snazzah/davey` で対応している (bot の音楽再生・speak の読み上げ共通)。音楽再生はかつての play-dl / ytdl-core / discord-player-plus から youtubei.js (Innertube) に移行済み。
 
 ## Cron ジョブ
 
-| スケジュール | 処理内容 |
-|---|---|
-| `0 0 * * *` (毎日0時) | ユーザーのガチャチケットをリセット |
-| `* * * * *` (毎分) | 1時間以上アイドル状態のチャットセッションをクリーンアップ |
+| パッケージ | スケジュール | 処理内容 |
+|---|---|---|
+| bot | `0 0 * * *` (毎日0時) | ユーザーのガチャチケットをリセット |
+| bot | `* * * * *` (毎分) | 1時間以上アイドル状態のチャットセッションをクリーンアップ |
+| speak | `* * * * *` (毎分) | 30分以上アイドル状態の LLM セッションを破棄 |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -23,6 +23,7 @@
 | `/help` | ヘルプを表示 |
 | `/nickname <name>` | ニックネームを設定 |
 | `/speak` | 読み上げ Bot を呼び出す |
+| `/discon` | 読み上げ Bot を切断する |
 | `/dict add <surface> <pronunciation> <accent_type> [word_type] [priority]` | 読み上げ辞書に単語を登録 |
 | `/dict list` | 読み上げ辞書の単語一覧を表示 |
 | `/dict remove <uuid>` | 読み上げ辞書から単語を削除 |
@@ -177,11 +178,15 @@
 
 ### 読み上げ (TTS)
 
-| コマンド | エイリアス | 説明 |
-|---|---|---|
-| `.speak` | | 読み上げを開始 |
-| `.discon` | | 読み上げを停止 |
-| `.speaker-config <voice> <speed>` | `.spcon` | 読み上げ設定 |
+`.speak` は bot 本体が処理し、未使用の読み上げ Bot インスタンス (`packages/speak`) を HTTP で呼び出します。それ以外は読み上げ Bot 側が直接処理するコマンドです (コマンド名はインスタンス別 JSON 設定で変更可能、以下はデフォルト)。
+
+| コマンド | エイリアス | 処理する Bot | 説明 |
+|---|---|---|---|
+| `.speak` | | bot | 読み上げ Bot を呼び出す |
+| `.discon` | | speak | 読み上げを停止・切断 |
+| `.speaker-config <voice_id> [speed] [pitch] [intonation]` | `.spcon` | speak | 読み上げ設定 (引数なしで現在の設定を表示) |
+| `.sp-reload` | | speak | スピーカー ID 一覧を再読込 |
+| `.<bot名> <text>` | | speak | 読み上げ Bot の LLM とチャット |
 
 ### 天気予報
 
@@ -197,3 +202,25 @@
 | `.pic` | ランダムな写真を表示 |
 | `.cat` | 猫の写真を表示 |
 | `.topic` | ランダムな話題を表示 |
+
+---
+
+## 読み上げ Bot (`packages/speak`) のスラッシュコマンド
+
+読み上げ Bot インスタンスが独自に登録するコマンドです。
+
+### サーバーコマンド (Guild)
+
+| コマンド | 説明 |
+|---|---|
+| `/speak` | 読み上げを呼び出す |
+
+### DM コマンド
+
+| コマンド | 説明 |
+|---|---|
+| `/delete [last]` | LLM とのチャット履歴を削除 |
+| `/revert [uuid]` | 最新のチャット履歴を復元 |
+| `/spcon <voice_id> [speed] [pitch] [intonation]` | 読み上げの声・スピード・ピッチ・抑揚を設定 |
+| `/model-list` | LLM モデル一覧を表示 |
+| `/model-set <model>` | LLM モデルを設定 |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,8 +1,8 @@
 # 設定ガイド
 
-## 設定ファイル
+## Bot (`packages/bot`) の設定
 
-設定テンプレートは `src/config/config.template.ts` にあります。これをコピーして `config.ts` を作成し、各値を環境に合わせて設定してください。
+設定テンプレートは `packages/bot/src/config/config.template.ts` にあります。これをコピーして `config.ts` を作成し、各値を環境に合わせて設定してください。
 
 ## 設定項目
 
@@ -41,6 +41,7 @@
 | キー | 型 | 説明 |
 |---|---|---|
 | `KEY` | string | Google Cloud API キー (YouTube Data API) |
+| `COOKIE` | string | youtubei.js 用のログイン済み Cookie (音楽再生。任意) |
 
 ### OPENAI - AI チャット設定
 
@@ -51,8 +52,8 @@
 | `PROJECT` | string \| undefined | OpenAI Project ID |
 | `KEY` | string | API キー |
 | `DEFAULT_MODEL` | LiteLLMModel | デフォルトモデル |
-| `G3_MODEL` | LiteLLMModel | 軽量モデル (low) |
-| `G4_MODEL` | LiteLLMModel | 高性能モデル (high) |
+| `LOW_MODEL` | LiteLLMModel | 軽量モデル (low) |
+| `HIGH_MODEL` | LiteLLMModel | 高性能モデル (high) |
 | `ACCESSTOKEN` | string | アクセストークン |
 
 ### NICONICO - ニコニコ動画設定
@@ -88,7 +89,30 @@ LiteLLM プロキシを経由して以下のモデルが利用可能です:
 - Claude 3.5 Sonnet / Claude 3.5 Haiku
 - Claude 3.7 Sonnet / Claude 3.7 Sonnet Reasoning
 
+## 読み上げ Bot (`packages/speak`) の設定
+
+speak は 2 種類の設定ファイルを使います。どちらも gitignore されています。
+
+1. **共通設定** — `packages/speak/src/config/config.template.ts` をコピーして `config.ts` を作成し、DB (bot と共通) / OpenAI の設定を記入
+2. **インスタンス別設定** — `src/config/example.json.template` をコピーして `src/config/<name>.json` を作成し、起動引数で渡す
+
+インスタンス別 JSON の項目:
+
+| キー | 型 | 説明 |
+|---|---|---|
+| `TOKEN` | string | そのインスタンスの Discord Bot トークン |
+| `APP_ID` | string | Discord アプリケーション ID |
+| `NAME` | string | Bot 名 (`.{NAME} <text>` で LLM チャットにも使用) |
+| `PORT` | number | HTTP サーバーのポート (例: lemon=4100, lime=4101) |
+| `COMMAND.SPEAK` | object | 読み上げ呼出コマンド名・スリープ時間 |
+| `COMMAND.SPEAKER_CONFIG` | object | 読み上げ設定コマンド (`speaker-config` / `spcon` / `sp-reload`) |
+| `COMMAND.DISCONNECT` | string | 切断コマンド名 (`discon`) |
+
+また、音声合成のため [voicevox_engine](https://github.com/VOICEVOX/voicevox_engine) (port 50021)、COEIROINK を使う場合はそのエンジン (port 50032) をローカルで起動しておく必要があります。
+
 ## Web API エンドポイント
+
+### Bot (`packages/bot`)
 
 Express サーバーが以下のエンドポイントを提供します:
 
@@ -101,4 +125,13 @@ Express サーバーが以下のエンドポイントを提供します:
 | POST | `/music/*` | 音楽制御 |
 | POST | `/speaker/*` | TTS 設定 |
 | POST | `/session/*` | セッション管理 |
-| POST | `/spotify/callback` | Spotify OAuth コールバック |
+
+### 読み上げ Bot (`packages/speak`)
+
+bot から呼び出される HTTP API:
+
+| メソッド | パス | 説明 |
+|---|---|---|
+| GET | `/speaker/status/:guildId` | 読み上げ Bot の使用状況を取得 |
+| POST | `/speaker/call` | ボイスチャンネルに読み上げ Bot を呼び出す |
+| POST | `/speaker/discon` | 読み上げ Bot を切断する |

--- a/docs/database.md
+++ b/docs/database.md
@@ -4,9 +4,9 @@
 
 - **DBMS:** MariaDB
 - **ORM:** TypeORM v0.3
-- **スキーマ同期:** `synchronize: true` (自動マイグレーション、Phase 2-1 で `false` に切り替え予定)
+- **スキーマ同期:** bot は `synchronize: true` (自動マイグレーション、Phase 2-1 で `false` に切り替え予定)。speak は同一 DB を共有する別プロセスのため `synchronize: false` で接続
 - **エンティティ数:** 17 (`packages/shared/src/models/`)
-- **DataSource ファクトリ:** `packages/shared/src/config/datasource.ts` の `createDataSource(config)` を bot から呼び出して初期化
+- **DataSource ファクトリ:** `packages/shared/src/config/datasource.ts` の `createDataSource(config)` を bot / speak から呼び出して初期化
 - **マイグレーション CLI:** `pnpm --filter @orangebot/shared migration:{generate,run,revert,show}` (DB_HOST/DB_PORT/DB_USERNAME/DB_PASSWORD/DB_DATABASE を `.env` で指定)
 
 > Discord ID 系の主キー (`id`, `guild_id`, `channel_id` 等) は DB 上は `bigint(20)` として定義されているが、TypeORM の慣習によりアプリケーション層では `string` として扱われる。
@@ -127,12 +127,21 @@
 | `event` | string | イベント名 |
 | `message` | string | メッセージ |
 
+### Speaker - 読み上げ Bot の使用状況
+
+読み上げ Bot (`packages/speak`) インスタンスの貸出状況を guild × bot ユーザー単位で管理する。bot の `.speak` / `/speak` が未使用インスタンスの検索に、speak の `/speaker/call` / `/speaker/discon` が使用状況の更新に使う。
+
+| カラム | 型 | 説明 |
+|---|---|---|
+| `guild_id` | string (PK) | ギルド ID |
+| `user_id` | string (PK) | 読み上げ Bot のユーザー ID (複合主キー) |
+| `is_used` | tinyint | 使用中フラグ |
+
 ### その他のエンティティ
 
 - **Color** - カラーデータ
 - **Role** - ユーザーロール
-- **Speaker** - TTS スピーカー設定
-- **UserSetting** - ユーザー個別設定
+- **UserSetting** - ユーザー個別設定 (読み上げの声 ID・スピード・ピッチ・抑揚を含む)
 - **Timer** - タイマーデータ
 - **MusicInfo** - 楽曲メタデータ
 - **BotInfo** - Bot 情報

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -13,13 +13,13 @@
 
 ### 2. `synchronize: true` が本番環境でも有効
 
-- **場所**: `packages/bot/src/model/typeorm/typeorm.ts:14`
-- **問題**: TypeORM の `synchronize: true` が環境チェックなしで常に有効。スキーマ変更時にカラムやテーブルが自動削除され、データ損失の可能性がある
+- **場所**: `packages/shared/src/config/datasource.ts` (`createDataSource` の `synchronize: config.synchronize ?? true`)
+- **問題**: bot は `synchronize` を指定せず起動するためデフォルトの `true` が常に有効。スキーマ変更時にカラムやテーブルが自動削除され、データ損失の可能性がある (speak は `false` を明示して接続)
 - **対策**: `NODE_ENV` で切り替え、本番では `false` にしてマイグレーションを使用
 
 ### 3. 非同期処理の未 await (Promise の握りつぶし)
 
-- **場所**: `packages/bot/src/app.ts:128` 付近 (`DISCORD_CLIENT.guilds.cache.map(async (guild) => ...)`)
+- **場所**: `packages/bot/src/app.ts` の ready イベント内 (`DISCORD_CLIENT.guilds.cache.map(async (guild) => ...)`)
 - **問題**: `.map()` 内の async 関数が await されていない
   ```typescript
   DISCORD_CLIENT.guilds.cache.map(async (guild) => {
@@ -40,14 +40,15 @@
 
 ### 5. ハードコードされた Discord ID
 
-- **場所**: `packages/bot/src/app.ts:262,336`, `packages/bot/src/bot/reactions.ts:58`, `packages/bot/src/bot/dot_function/chat_tools/userActivity.ts:6`, `packages/bot/src/bot/manager/handlers/interactions/lyrics.handler.ts:27`, `packages/bot/src/config/config.ts:37`
+- **場所**: `packages/bot/src/app.ts`, `packages/bot/src/bot/reactions.ts`, `packages/bot/src/bot/dot_function/chat_tools/userActivity.ts`, `packages/bot/src/bot/manager/handlers/interactions/lyrics.handler.ts`, `packages/bot/src/bot/dot_function/speak.ts`, `packages/bot/src/config/config.ts`
 - **問題**: チャンネル ID やギルド ID がソースコードに直接埋め込まれている
   - `'1020972071460814868'`, `'1239718107073875978'`, `'1017341244508225596'` 等
+  - `speak.ts` には読み上げ Bot のユーザー ID (`LEMON_SPEAKER_ID` / `LIME_SPEAKER_ID`) と呼出先 URI (`http://127.0.0.1:4100` 等) もハードコード
 - **対策**: 設定ファイルまたは DB のギルド設定に移動
 
 ### 6. イベントハンドラに try/catch がない
 
-- **場所**: `packages/bot/src/app.ts:188-308` (`messageCreate` イベント等)
+- **場所**: `packages/bot/src/app.ts` (`messageCreate` イベント等)
 - **問題**: ハンドラ内で例外が発生するとイベント処理全体が停止し、Bot が無応答になる可能性
 - **対策**: 各イベントハンドラのトップレベルに try/catch を追加
 
@@ -59,13 +60,13 @@
 
 ### 8. CORS が全オリジン許可
 
-- **場所**: `packages/bot/src/app.ts:43`
+- **場所**: `packages/bot/src/app.ts` (`app.use(cors())`)
 - **問題**: `app.use(cors())` で全オリジンからのリクエストを許可
 - **対策**: 許可するオリジンを明示的に指定
 
 ### 9. DB コネクションプール設定がない
 
-- **場所**: `packages/bot/src/model/typeorm/typeorm.ts`
+- **場所**: `packages/shared/src/config/datasource.ts`
 - **問題**: MariaDB のプール設定がデフォルトのまま。並行リクエスト増加時にコネクション枯渇の恐れ
 - **対策**: `poolSize`, `maxConnections`, `minConnections` を明示的に設定
 
@@ -110,19 +111,19 @@
 
 ### 16. ソフトデリートのカスケードがない
 
-- **場所**: `packages/bot/src/model/repository/usersRepository.ts`
+- **場所**: `packages/shared/src/repository/usersRepository.ts`
 - **問題**: ユーザーをソフトデリートしても、関連する gacha / settings レコードが残り、クエリ不整合の原因になる
 - **対策**: カスケードソフトデリートロジックの実装、またはリレーション設定の見直し
 
 ### 17. DB インデックスの不足
 
-- **場所**: `packages/bot/src/model/models/*.ts`
+- **場所**: `packages/shared/src/models/*.ts`
 - **問題**: `user_id`, `guild_id`, `channel_id` 等の頻出検索カラムにインデックスが未設定の可能性
 - **対策**: 頻繁にクエリされるカラムに `@Index()` デコレータを追加
 
 ### 18. 環境別の設定切り替えがない
 
-- **場所**: `packages/bot/src/config/config.template.ts`, `packages/bot/src/model/typeorm/typeorm.ts`
+- **場所**: `packages/bot/src/config/config.template.ts`, `packages/shared/src/config/datasource.ts`
 - **問題**: `NODE_ENV` による設定の切り替え機構がなく、開発/本番で同じ設定が適用される
 - **対策**: 環境変数ベースの設定切り替えを実装
 

--- a/docs/migration-proposal.md
+++ b/docs/migration-proposal.md
@@ -1,10 +1,11 @@
 # 次フェーズ移行提案: モノレポ化 + API サーバー / フロントエンド新設
 
-> **進捗ステータス (2026-05 時点)**:
+> **進捗ステータス (2026-06 時点)**:
 > - **Phase 1-1 (パッケージマネージャ移行): 完了** — pnpm + workspace へ移行済み、未使用依存 (`@sequelize/core` / `fs` / `kysely` / `sqlite3` / `pg` / `pg-hstore`) も削除済み
 > - **Phase 1-2 (モノレポ構成・ワークスペース設定): 完了** — `packages/bot` / `packages/shared` の骨格と `pnpm-workspace.yaml` / `tsconfig.base.json` / smoke-test スクリプトが存在
 > - **Phase 1-3 (shared への切り出し): 完了** — モデル17個・リポジトリ13個・DataSource ファクトリ・Logger ポート (`getLogger`/`setLogger`)・`MusicAddItem` DTO を `@orangebot/shared` に集約。`bot/model/` と `bot/type/types.ts` は削除し、bot 全ファイルが `@orangebot/shared` 経由でアクセスする状態。`RoomRepository.init()` と `ChatHistoryRepository.getLatestByChannelId()` の Discord 依存は bot 側 (app.ts / revert.handler) に押し戻し済み
 > - **Phase 1-4 (ビルド・開発環境整備): 完了** — ルート/bot の `pnpm` スクリプトに `predev` / `presmoke-test` を追加して shared を先にビルド、TypeORM マイグレーション基盤 (`packages/shared/scripts/data-source-cli.ts` + `migration:*` scripts + `src/migrations/`) を整備。`synchronize: false` への切り替えは Phase 2-1 で実施
+> - **計画外の追加: `packages/speak` (2026-06)** — 別リポジトリだった speak-voicevox を読み上げ Bot として monorepo に統合。DB 層は `@orangebot/shared` を再利用し、bot からは HTTP (`/speaker/call` 等) で呼び出す。本提案の Phase 構成には影響しない
 > 次の作業は Phase 2-1 (テスト基盤 + 純粋ロジックの移動) から。
 
 ## 1. 背景と目的
@@ -75,6 +76,11 @@ ts-orangebot/
 │   │   │   ├── handlers/          ← コマンドハンドラ
 │   │   │   ├── managers/          ← メッセージ/インタラクション管理
 │   │   │   └── adapters/          ← shared サービスと Discord の橋渡し
+│   │   ├── package.json
+│   │   └── tsconfig.json
+│   │
+│   ├── speak/                      ← 読み上げ Bot (旧 speak-voicevox を統合済み)
+│   │   ├── src/
 │   │   ├── package.json
 │   │   └── tsconfig.json
 │   │

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -14,18 +14,19 @@ OrangeBot-TS は、Orange Server 向けの多機能 Discord Bot です。TypeScr
 | ORM | TypeORM v0.3 |
 | データベース | MariaDB |
 | AI | OpenAI API (LiteLLM プロキシ経由) |
-| 音楽再生 | discord-player-plus / @discordjs/voice / @distube/ytdl-core |
+| 音楽再生 | @discordjs/voice / youtubei.js (Innertube) |
+| 読み上げ (TTS) | VOICEVOX / COEIROINK (`packages/speak`) |
 | スケジューラ | node-cron |
 
 ## 主要機能
 
 - **ボイスチャンネル管理** - ロビーに参加すると自動でルームを作成、退出時に自動削除
 - **ガチャシステム** - 毎日リセットされるチケットでアイテムを引く
-- **音楽再生** - YouTube の検索・再生、プレイリスト管理、ループ・シャッフル
+- **音楽再生** - YouTube の検索・再生 (youtubei.js)、プレイリスト管理、ループ・シャッフル
 - **AI チャット** - LiteLLM プロキシ経由で複数の LLM モデル (GPT-4, Claude 等) を利用。Tool Calling により天気・ユーザーアクティビティ等のコンテキストを自動取得
 - **天気予報** - OpenWeatherMap API による地域別天気予報
 - **ゲーム** - ダイス、チンチロリン、チーム分け、ITO 等
-- **読み上げ (TTS)** - VOICEVOX 連携によるテキスト読み上げ
+- **読み上げ (TTS)** - 専用の読み上げ Bot (`packages/speak`) を HTTP で呼び出してテキストを読み上げ。VOICEVOX / COEIROINK 対応
 - **管理機能** - ミュート、タイムアウト、ユーザー権限管理
 
 ## エントリーポイント
@@ -39,21 +40,25 @@ OrangeBot-TS は、Orange Server 向けの多機能 Discord Bot です。TypeScr
 5. スラッシュコマンドの登録
 6. Cron ジョブの初期化
 
+読み上げ Bot のエントリーポイントは `packages/speak/src/app.ts` です。インスタンス別の JSON 設定 (`src/config/<name>.json`) を引数に取り、Express サーバー起動 → MariaDB 接続 (bot と同一 DB、`synchronize: false`) → Discord ログイン → 読み上げ用スラッシュコマンド登録を行います。インスタンスごとに別の Discord トークン / ポートで複数起動できます (例: lemon=4100, lime=4101)。
+
 ## モノレポ構成
 
 pnpm workspace を採用しており、以下のパッケージで構成されています:
 
 - `packages/bot` — Discord Bot 本体 (Express + Discord.js)
 - `packages/shared` — 共有層 (TypeORM エンティティ / リポジトリ / DataSource ファクトリ / 共通型)
+- `packages/speak` — 読み上げ Bot (VOICEVOX / COEIROINK)。bot から HTTP (`/speaker/call` 等) で呼び出され、複数インスタンス起動可能
 
 ## pnpm スクリプト
 
 ルートから実行するスクリプト:
 
 ```bash
-pnpm build        # 全パッケージをビルド (pnpm -r build, shared → bot の順)
+pnpm build        # 全パッケージをビルド (pnpm -r build, shared → bot/speak の順)
 pnpm clean        # 全パッケージの dist を削除
 pnpm dev          # shared をビルド後、Bot を nodemon で開発モード起動
+pnpm dev:speak    # shared をビルド後、読み上げ Bot を開発モード起動 (src/config/dev.json を使用)
 pnpm lint         # Bot に対して ESLint
 pnpm smoke-test   # shared をビルド後、Bot の起動疎通確認
 ```
@@ -63,6 +68,13 @@ Bot パッケージ単体での操作:
 ```bash
 pnpm --filter @orangebot/bot start         # ビルド成果物を実行
 pnpm --filter @orangebot/bot smoke-test    # 起動 〜 シャットダウンの疎通確認
+```
+
+読み上げ Bot (speak) 単体での操作:
+
+```bash
+pnpm --filter @orangebot/speak build                          # ビルド
+pnpm --filter @orangebot/speak start src/config/<name>.json   # インスタンス別設定で起動
 ```
 
 shared パッケージのマイグレーション CLI (Phase 2-1 以降に本格運用):


### PR DESCRIPTION
## 概要

`packages/speak` の追加 (#29)、`/dict` コマンド (#30)、E2EE 対応と音楽再生の youtubei.js 移行 (#31) を docs/ 配下のドキュメントに反映しました。

## 変更内容

- **overview.md** — 技術スタック (youtubei.js / TTS 行)、モノレポ構成と pnpm スクリプトに speak を追加、speak のエントリーポイントを追記
- **architecture.md** — speak パッケージの構成セクションを新設 (ディレクトリ構成 / HTTP API / VOICEVOX・COEIROINK 連携)、読み上げのメッセージフロー、E2EE (DAVE) の節、Cron ジョブ表の更新、`request/innertube.ts` の追記
- **configuration.md** — `OPENAI.LOW_MODEL/HIGH_MODEL` への修正、`YOUTUBE.COOKIE` 追加、speak の設定 (config.ts + インスタンス別 JSON) と HTTP エンドポイントを追加、未登録の `/spotify/callback` を削除
- **database.md** — Speaker エンティティの詳細化、speak が `synchronize: false` で同一 DB を共有する旨を追記
- **commands.md** — `/discon` 追加、TTS コマンド表を処理 Bot 別に再構成、speak 自身のスラッシュコマンド一覧を新設
- **issues.md** — shared 移動で無効になっていたパスを修正、行番号指定をコード断片に置換、#5 に speak.ts のハードコード ID/URI を追加
- **migration-proposal.md** — 進捗を 2026-06 に更新し、計画外の speak 統合をステータスと構成図に反映

🤖 Generated with [Claude Code](https://claude.com/claude-code)