### PR TITLE
feat: niconico-dl を play コマンドに統合

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ output/
 youtubeCookie.json
 *-player-script.js
 .cache/
+.pnpm-store/

--- a/niconico-dl/.gitignore
+++ b/niconico-dl/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+*.mp4
+*.mkv
+*.ts.tsbuildinfo
+.DS_Store

--- a/niconico-dl/README.md
+++ b/niconico-dl/README.md
@@ -1,0 +1,100 @@
+# niconico-dl
+
+ニコニコ動画のメタデータ取得と、ffmpeg を用いたストリーム取得を行う TypeScript 製 npm モジュール。`youtube.js` のような感覚で利用できる。
+
+現行（2025 年のサーバ移行後）のニコニコの DMS / domand HLS 配信に対応する。watch API でメタデータと `accessRightKey` を取得し、`access-rights/hls` で払い出される m3u8 と `domand_bid` Cookie を ffmpeg に渡してリマックスする。
+
+## 特徴
+
+- watch API (`v3` / `v3_guest`) からメタデータ・画質一覧を取得
+- Cookie / セッション認証（会員限定・年齢制限動画にも `user_session` を渡せば対応）
+- `access-rights/hls` 経由で HLS を取得し、ffmpeg で `-c copy`（再エンコードなし）
+- Node の `Readable` ストリームとして取得、またはファイルへ直接保存
+- 依存ライブラリゼロ（ffmpeg を除く）、strict TypeScript
+
+## 必要環境
+
+- Node.js 18.17 以上（グローバル `fetch` と `Headers.getSetCookie()` を使用）
+- ffmpeg（システムにインストール、または `ffmpeg-static` を導入）
+
+```bash
+npm install niconico-dl
+npm install ffmpeg-static   # 任意。なければ PATH 上の ffmpeg を使用
+```
+
+## 使い方
+
+```ts
+import { NiconicoClient } from "niconico-dl";
+import fs from "node:fs";
+
+// 既存セッションを使う場合（推奨）
+const nico = new NiconicoClient({ userSession: process.env.NICO_SESSION });
+
+// または ID/パスワードでログイン（二段階認証アカウントは非対応）
+// await nico.login("mail@example.com", "password");
+
+// メタデータ取得
+const info = await nico.getInfo("https://www.nicovideo.jp/watch/sm9");
+console.log(info.title, info.durationSec, info.formats);
+
+// ストリーム取得
+const { stream, done } = await nico.getStream("sm9", { quality: "best" });
+stream.pipe(fs.createWriteStream("out.mp4"));
+await done;
+
+// あるいはファイルへ直接保存
+await nico.download("sm9", "out.mp4", { quality: "best" });
+```
+
+## API
+
+### `new NiconicoClient(options?)`
+
+| オプション      | 型                  | 説明                                              |
+| --------------- | ------------------- | ------------------------------------------------- |
+| `userSession`   | `string`            | `user_session` Cookie。指定でログイン済み扱い     |
+| `cookie`        | `string`            | `"a=b; c=d"` 形式の Cookie ヘッダをまとめて投入    |
+| `userAgent`     | `string`            | User-Agent の上書き                               |
+| `fetch`         | `typeof fetch`      | fetch 実装の差し替え（テスト用）                  |
+
+### メソッド
+
+- `getInfo(urlOrId)` → `Promise<VideoInfo>` — メタデータと画質一覧
+- `getStream(urlOrId, options?)` → `Promise<VideoStream>` — `{ stream, done, format, kill }`
+- `getStreamFromInfo(info, options?)` — 取得済み `VideoInfo` から（メタデータ再取得を省略）
+- `download(urlOrId, destPath, options?)` — ファイルへ保存
+- `login(mailTel, password)` — ログイン
+- `exportCookies()` → `string` — セッション Cookie を保存用に書き出し
+- `isLoggedIn` — ログイン状態
+
+### `StreamOptions`
+
+| オプション    | 型                                              | 既定      | 説明                                  |
+| ------------- | ----------------------------------------------- | --------- | ------------------------------------- |
+| `quality`     | `"best" \| "worst" \| (formats) => FormatInfo`  | `"best"`  | 取得画質                              |
+| `container`   | `"mp4" \| "matroska" \| "mpegts"`               | `"mp4"`   | 出力コンテナ（mp4 はフラグメント mp4）|
+| `ffmpegPath`  | `string`                                        | 自動解決  | ffmpeg のパス                         |
+| `extraArgs`   | `string[]`                                      | `[]`      | ffmpeg への追加引数                   |
+| `signal`      | `AbortSignal`                                   | —         | 中断用                                |
+
+## エラー
+
+- `LoginRequiredError` — 会員限定・年齢制限・PPV・セッション無効
+- `VideoUnavailableError` — 削除・非公開・地域制限（`code` / `reasonCode` を保持）
+- `FfmpegError` — ffmpeg の起動・実行失敗
+- `NiconicoError` — 上記の基底
+
+## 仕組み
+
+1. `GET /api/watch/v3(_guest)/{id}` でメタデータ・`media.domand`・`accessRightKey`・`watchTrackId` を取得
+2. `POST nvapi.nicovideo.jp/v1/watch/{id}/access-rights/hls`（`X-Access-Right-Key` 付き、ボディ `{outputs:[[videoId,audioId]]}`）で m3u8 の `contentUrl` を取得
+3. 同レスポンスで払い出される `domand_bid` Cookie を含めて ffmpeg を起動し、HLS を mp4 へリマックス
+
+## 注意
+
+ニコニコの API 仕様は予告なく変更されることがある。取得したコンテンツの利用は、ニコニコの利用規約および著作権法を遵守すること。本モジュールは私的利用・技術検証を目的とする。
+
+## ライセンス
+
+MIT

--- a/niconico-dl/examples/download.mjs
+++ b/niconico-dl/examples/download.mjs
@@ -1,0 +1,18 @@
+// 動画をファイルに保存する例。
+// 実行: NICO_SESSION=xxxx node examples/download.mjs sm9 out.mp4
+import { NiconicoClient } from "../dist/index.js";
+
+const [, , target = "sm9", dest = "out.mp4"] = process.argv;
+
+const nico = new NiconicoClient({ userSession: process.env.NICO_SESSION });
+
+const info = await nico.getInfo(target);
+console.log(`タイトル: ${info.title}`);
+console.log(`再生時間: ${info.durationSec}s / 再生数: ${info.viewCount}`);
+console.log(
+  "画質:",
+  info.formats.map((f) => `${f.label}(${Math.round(f.totalBitRate / 1000)}kbps)`).join(", "),
+);
+
+const { format } = await nico.download(target, dest, { quality: "best" });
+console.log(`保存完了: ${dest} (${format.label})`);

--- a/niconico-dl/examples/stream.mjs
+++ b/niconico-dl/examples/stream.mjs
@@ -1,0 +1,17 @@
+// Readable ストリームとして取得し、任意の出力へパイプする例。
+// 実行: NICO_SESSION=xxxx node examples/stream.mjs sm9 > out.mp4
+import { NiconicoClient } from "../dist/index.js";
+
+const [, , target = "sm9"] = process.argv;
+
+const nico = new NiconicoClient({ userSession: process.env.NICO_SESSION });
+
+const { stream, done, format } = await nico.getStream(target, {
+  quality: "best",
+  container: "mp4",
+});
+
+console.error(`取得中: ${format.label}`);
+stream.pipe(process.stdout);
+await done;
+console.error("完了");

--- a/niconico-dl/package-lock.json
+++ b/niconico-dl/package-lock.json
@@ -1,0 +1,59 @@
+{
+  "name": "niconico-dl",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "niconico-dl",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^20.11.0",
+        "typescript": "^5.4.0"
+      },
+      "engines": {
+        "node": ">=18.17"
+      },
+      "peerDependencies": {
+        "ffmpeg-static": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ffmpeg-static": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/niconico-dl/package.json
+++ b/niconico-dl/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "niconico-dl",
+  "version": "0.1.0",
+  "description": "youtube.js のように使える、ニコニコ動画のメタデータ取得 + ffmpeg ストリーム取得モジュール",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "types": "./dist/index.d.ts",
+  "main": "./dist/index.js",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=18.17"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "keywords": [
+    "niconico",
+    "nicovideo",
+    "downloader",
+    "hls",
+    "ffmpeg",
+    "stream"
+  ],
+  "license": "MIT",
+  "peerDependencies": {
+    "ffmpeg-static": "^5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "ffmpeg-static": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/niconico-dl/src/client.ts
+++ b/niconico-dl/src/client.ts
@@ -1,0 +1,187 @@
+import type { Readable } from "node:stream";
+import { CookieJar } from "./cookies.js";
+import { LoginRequiredError, NiconicoError } from "./errors.js";
+import { spawnFfmpegStream, streamToFile } from "./ffmpeg.js";
+import {
+  extractVideoId,
+  fetchHls,
+  fetchVideoInfo,
+} from "./watch.js";
+import type {
+  ClientOptions,
+  FormatInfo,
+  QualitySelector,
+  StreamOptions,
+  VideoInfo,
+} from "./types.js";
+
+const DEFAULT_UA =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
+  "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
+const LOGIN_BASE = "https://account.nicovideo.jp";
+const WATCH_REFERER = "https://www.nicovideo.jp/";
+
+/** ストリーム取得結果。 */
+export interface VideoStream {
+  /** 多重化済みの動画データ（mp4 等）。 */
+  stream: Readable;
+  /** ffmpeg プロセスの終了を待つ Promise。 */
+  done: Promise<void>;
+  /** 取得に用いたフォーマット。 */
+  format: FormatInfo;
+  /** 明示的に中断する。 */
+  kill: () => void;
+}
+
+/**
+ * ニコニコ動画クライアント。
+ *
+ * @example
+ * const nico = new NiconicoClient({ userSession: process.env.NICO_SESSION });
+ * const info = await nico.getInfo("sm9");
+ * const { stream } = await nico.getStream("sm9");
+ * stream.pipe(fs.createWriteStream("out.mp4"));
+ */
+export class NiconicoClient {
+  private readonly jar = new CookieJar();
+  private readonly userAgent: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: ClientOptions = {}) {
+    this.userAgent = options.userAgent ?? DEFAULT_UA;
+    this.fetchImpl = options.fetch ?? globalThis.fetch;
+    if (!this.fetchImpl) {
+      throw new NiconicoError(
+        "fetch が利用できません。Node 18 以上を使うか options.fetch を指定してください",
+      );
+    }
+    if (options.cookie) this.jar.setFromHeaderString(options.cookie);
+    if (options.userSession) {
+      this.jar.set({ name: "user_session", value: options.userSession });
+    }
+  }
+
+  /** user_session の有無でログイン状態を判定。 */
+  get isLoggedIn(): boolean {
+    return this.jar.has("user_session");
+  }
+
+  private deps() {
+    return { jar: this.jar, userAgent: this.userAgent, fetchImpl: this.fetchImpl };
+  }
+
+  /**
+   * メール/パスワードでログインし、セッション Cookie を取得する。
+   * 二段階認証が有効なアカウントは未対応（事前に userSession を渡す方式を推奨）。
+   */
+  async login(mailTel: string, password: string): Promise<void> {
+    if (this.isLoggedIn) return;
+
+    // セッション Cookie を確立。
+    const pre = await this.fetchImpl(`${LOGIN_BASE}/login`, {
+      headers: { "User-Agent": this.userAgent, Cookie: this.jar.toHeader() },
+    });
+    this.jar.setFromResponse(pre);
+
+    const res = await this.fetchImpl(`${LOGIN_BASE}/login/redirector`, {
+      method: "POST",
+      redirect: "manual",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Referer: `${LOGIN_BASE}/login`,
+        "User-Agent": this.userAgent,
+        Cookie: this.jar.toHeader(),
+      },
+      body: new URLSearchParams({ mail_tel: mailTel, password }).toString(),
+    });
+    this.jar.setFromResponse(res);
+
+    if (!this.isLoggedIn) {
+      throw new LoginRequiredError(
+        "ログインに失敗しました（認証情報が誤っているか、二段階認証が有効です）",
+      );
+    }
+  }
+
+  /** 取得済みのセッション Cookie をエクスポート（再利用・保存用）。 */
+  exportCookies(): string {
+    return this.jar.toHeader();
+  }
+
+  /** 動画メタデータと利用可能フォーマットを取得。 */
+  async getInfo(urlOrId: string): Promise<VideoInfo> {
+    const videoId = extractVideoId(urlOrId);
+    return fetchVideoInfo(videoId, this.deps());
+  }
+
+  /**
+   * 動画ストリームを取得する。内部で access-rights/hls → ffmpeg を実行。
+   * @param urlOrId watch URL または ID
+   */
+  async getStream(
+    urlOrId: string,
+    options: StreamOptions = {},
+  ): Promise<VideoStream> {
+    const videoId = extractVideoId(urlOrId);
+    const info = await fetchVideoInfo(videoId, this.deps());
+    return this.getStreamFromInfo(info, options);
+  }
+
+  /** 取得済みの VideoInfo からストリームを取得（メタデータ再取得を省略）。 */
+  async getStreamFromInfo(
+    info: VideoInfo,
+    options: StreamOptions = {},
+  ): Promise<VideoStream> {
+    if (info.formats.length === 0) {
+      throw new NiconicoError(
+        "再生可能なフォーマットがありません（会員限定・PPV の可能性。ログインを確認してください）",
+      );
+    }
+
+    const format = selectFormat(info.formats, options.quality ?? "best");
+    const hls = await fetchHls(
+      info.id,
+      info.raw,
+      [[format.videoId, format.audioId]],
+      this.deps(),
+    );
+
+    const { stream, done, kill } = spawnFfmpegStream(
+      {
+        m3u8Url: hls.contentUrl,
+        cookieHeader: hls.cookieHeader,
+        userAgent: this.userAgent,
+        referer: WATCH_REFERER,
+      },
+      options,
+    );
+
+    return { stream, done, format, kill };
+  }
+
+  /** 動画を指定パスへダウンロード保存する。 */
+  async download(
+    urlOrId: string,
+    destPath: string,
+    options: StreamOptions = {},
+  ): Promise<{ format: FormatInfo; info: VideoInfo }> {
+    const videoId = extractVideoId(urlOrId);
+    const info = await fetchVideoInfo(videoId, this.deps());
+    const result = await this.getStreamFromInfo(info, options);
+    await streamToFile(
+      { stream: result.stream, done: result.done, kill: result.kill },
+      destPath,
+    );
+    return { format: result.format, info };
+  }
+}
+
+function selectFormat(
+  formats: FormatInfo[],
+  selector: QualitySelector,
+): FormatInfo {
+  if (typeof selector === "function") return selector(formats);
+  // formats は totalBitRate 昇順。
+  if (selector === "worst") return formats[0]!;
+  return formats[formats.length - 1]!; // best
+}

--- a/niconico-dl/src/cookies.ts
+++ b/niconico-dl/src/cookies.ts
@@ -1,0 +1,75 @@
+/**
+ * 依存ライブラリなしの最小 Cookie ジャー。
+ * fetch は Set-Cookie を自動管理しないため、ニコニコのセッション
+ * (user_session) と HLS 配信用 (domand_bid) を自前で保持する。
+ */
+
+export interface Cookie {
+  name: string;
+  value: string;
+  domain?: string;
+  path?: string;
+}
+
+export class CookieJar {
+  private readonly store = new Map<string, Cookie>();
+
+  /** name=value 形式の文字列、または Cookie オブジェクトを取り込む。 */
+  set(input: string | Cookie): void {
+    const cookie = typeof input === "string" ? CookieJar.parse(input) : input;
+    if (!cookie) return;
+    this.store.set(cookie.name, cookie);
+  }
+
+  /** "a=b; c=d" 形式の Cookie ヘッダ値（セミコロン区切り）をまとめて取り込む。 */
+  setFromHeaderString(header: string): void {
+    for (const part of header.split(/;\s*/)) {
+      const trimmed = part.trim();
+      if (trimmed && trimmed.includes("=")) this.set(trimmed);
+    }
+  }
+
+  /** レスポンスの Set-Cookie 群（getSetCookie() の配列）を取り込む。 */
+  setFromResponse(res: Response): void {
+    const anyHeaders = res.headers as Headers & {
+      getSetCookie?: () => string[];
+    };
+    const list = anyHeaders.getSetCookie?.() ?? [];
+    for (const raw of list) this.set(raw);
+  }
+
+  get(name: string): string | undefined {
+    return this.store.get(name)?.value;
+  }
+
+  has(name: string): boolean {
+    return this.store.has(name);
+  }
+
+  /** fetch / ffmpeg に渡せる "a=b; c=d" 形式の Cookie ヘッダ値を生成。 */
+  toHeader(): string {
+    return [...this.store.values()]
+      .map((c) => `${c.name}=${c.value}`)
+      .join("; ");
+  }
+
+  /** Set-Cookie ヘッダ1行をパース。属性(Path/Domain)以外は無視。 */
+  private static parse(raw: string): Cookie | null {
+    const [pair, ...attrs] = raw.split(/;\s*/);
+    if (!pair) return null;
+    const eq = pair.indexOf("=");
+    if (eq < 0) return null;
+    const name = pair.slice(0, eq).trim();
+    const value = pair.slice(eq + 1).trim();
+    if (!name) return null;
+
+    const cookie: Cookie = { name, value };
+    for (const attr of attrs) {
+      const [k, v] = attr.split("=");
+      const key = k?.trim().toLowerCase();
+      if (key === "domain") cookie.domain = v?.trim();
+      else if (key === "path") cookie.path = v?.trim();
+    }
+    return cookie;
+  }
+}

--- a/niconico-dl/src/errors.ts
+++ b/niconico-dl/src/errors.ts
@@ -1,0 +1,35 @@
+/** ニコニコ関連の処理で発生する基底エラー。 */
+export class NiconicoError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NiconicoError";
+  }
+}
+
+/** ログインが必要、またはセッションが無効な場合。 */
+export class LoginRequiredError extends NiconicoError {
+  constructor(message = "ログインが必要です（会員限定・年齢制限・PPV など）") {
+    super(message);
+    this.name = "LoginRequiredError";
+  }
+}
+
+/** 動画が取得不可（削除・非公開・地域制限など）。 */
+export class VideoUnavailableError extends NiconicoError {
+  constructor(
+    message: string,
+    public readonly code?: string,
+    public readonly reasonCode?: string,
+  ) {
+    super(message);
+    this.name = "VideoUnavailableError";
+  }
+}
+
+/** ffmpeg の実行に失敗した場合。 */
+export class FfmpegError extends NiconicoError {
+  constructor(message: string) {
+    super(message);
+    this.name = "FfmpegError";
+  }
+}

--- a/niconico-dl/src/ffmpeg.ts
+++ b/niconico-dl/src/ffmpeg.ts
@@ -1,0 +1,130 @@
+import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
+import { createWriteStream } from "node:fs";
+import { pipeline } from "node:stream/promises";
+import type { Readable } from "node:stream";
+import { FfmpegError } from "./errors.js";
+import type { StreamOptions } from "./types.js";
+
+/** ffmpeg 実行ファイルのパスを解決する。 */
+export function resolveFfmpegPath(explicit?: string): string {
+  if (explicit) return explicit;
+  // ffmpeg-static があれば優先。なければ PATH 上の "ffmpeg" を使う。
+  try {
+    const require = createRequire(import.meta.url);
+    const p = require("ffmpeg-static") as string | null;
+    if (p) return p;
+  } catch {
+    // ffmpeg-static 未インストール。フォールバックする。
+  }
+  return "ffmpeg";
+}
+
+const CONTAINER_ARGS: Record<NonNullable<StreamOptions["container"]>, string[]> =
+  {
+    // パイプ出力で再生可能にするためフラグメント mp4 にする。
+    mp4: ["-f", "mp4", "-movflags", "frag_keyframe+empty_moov+default_base_moof"],
+    matroska: ["-f", "matroska"],
+    mpegts: ["-f", "mpegts"],
+  };
+
+export interface FfmpegStreamInput {
+  m3u8Url: string;
+  cookieHeader: string;
+  userAgent: string;
+  referer: string;
+}
+
+interface SpawnResult {
+  /** 多重化された動画の Readable（ffmpeg stdout）。 */
+  stream: Readable;
+  /** プロセス終了を待つ Promise。非0終了で FfmpegError。 */
+  done: Promise<void>;
+  /** 明示的に中断する。 */
+  kill: () => void;
+}
+
+/**
+ * ffmpeg を起動し、HLS を取得して指定コンテナにリマックスした
+ * Readable ストリームを返す（再エンコードせず -c copy）。
+ */
+export function spawnFfmpegStream(
+  input: FfmpegStreamInput,
+  options: StreamOptions = {},
+): SpawnResult {
+  const container = options.container ?? "mp4";
+  const ffmpegPath = resolveFfmpegPath(options.ffmpegPath);
+
+  // HTTP リクエストヘッダ。CRLF 区切りで -headers に渡す。
+  const headers =
+    [`Cookie: ${input.cookieHeader}`, `Referer: ${input.referer}`].join(
+      "\r\n",
+    ) + "\r\n";
+
+  const args = [
+    "-hide_banner",
+    "-loglevel",
+    "error",
+    "-user_agent",
+    input.userAgent,
+    "-headers",
+    headers,
+    "-i",
+    input.m3u8Url,
+    "-c",
+    "copy",
+    ...CONTAINER_ARGS[container],
+    ...(options.extraArgs ?? []),
+    "pipe:1",
+  ];
+
+  const child = spawn(ffmpegPath, args, {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let stderr = "";
+  child.stderr.on("data", (chunk: Buffer) => {
+    // 直近のエラー出力のみ保持（肥大化防止）。
+    stderr = (stderr + chunk.toString()).slice(-4000);
+  });
+
+  const done = new Promise<void>((resolve, reject) => {
+    child.on("error", (err) => {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        reject(
+          new FfmpegError(
+            `ffmpeg が見つかりません (${ffmpegPath})。ffmpeg-static を入れるか ffmpegPath を指定してください`,
+          ),
+        );
+      } else {
+        reject(new FfmpegError(`ffmpeg の起動に失敗: ${err.message}`));
+      }
+    });
+    child.on("close", (code) => {
+      if (code === 0 || code === null) resolve();
+      else reject(new FfmpegError(`ffmpeg が異常終了しました (code=${code})\n${stderr}`));
+    });
+  });
+
+  const kill = () => {
+    if (!child.killed) child.kill("SIGKILL");
+  };
+
+  if (options.signal) {
+    if (options.signal.aborted) kill();
+    else options.signal.addEventListener("abort", kill, { once: true });
+  }
+
+  return { stream: child.stdout, done, kill };
+}
+
+/** ストリームをファイルへ書き出すユーティリティ。 */
+export async function streamToFile(
+  result: SpawnResult,
+  destPath: string,
+): Promise<void> {
+  await Promise.all([
+    pipeline(result.stream, createWriteStream(destPath)),
+    result.done,
+  ]);
+}

--- a/niconico-dl/src/index.ts
+++ b/niconico-dl/src/index.ts
@@ -1,0 +1,18 @@
+export { NiconicoClient } from "./client.js";
+export type { VideoStream } from "./client.js";
+export { CookieJar } from "./cookies.js";
+export {
+  FfmpegError,
+  LoginRequiredError,
+  NiconicoError,
+  VideoUnavailableError,
+} from "./errors.js";
+export { resolveFfmpegPath } from "./ffmpeg.js";
+export { extractVideoId } from "./watch.js";
+export type {
+  ClientOptions,
+  FormatInfo,
+  QualitySelector,
+  StreamOptions,
+  VideoInfo,
+} from "./types.js";

--- a/niconico-dl/src/types.ts
+++ b/niconico-dl/src/types.ts
@@ -1,0 +1,118 @@
+/** ニコニコ watch API (v3 / v3_guest) のレスポンスのうち、本モジュールが利用する部分。 */
+
+export interface DomandSource {
+  id: string;
+  isAvailable: boolean;
+  label?: string;
+  bitRate?: number;
+  width?: number;
+  height?: number;
+  qualityLevel?: number;
+  samplingRate?: number;
+}
+
+export interface WatchApiData {
+  client?: {
+    watchId?: string;
+    watchTrackId?: string;
+  };
+  media?: {
+    domand?: {
+      videos?: DomandSource[];
+      audios?: DomandSource[];
+      accessRightKey?: string;
+    };
+  };
+  video?: {
+    id?: string;
+    title?: string;
+    description?: string;
+    duration?: number;
+    registeredAt?: string;
+    count?: {
+      view?: number;
+      comment?: number;
+      like?: number;
+    };
+    thumbnail?: Record<string, string>;
+  };
+  owner?: { id?: number | string; nickname?: string };
+  channel?: { id?: string; name?: string };
+  tag?: { items?: Array<{ name?: string }> };
+  genre?: { label?: string };
+  reasonCode?: string;
+  publishScheduledAt?: string;
+}
+
+export interface WatchApiResponse {
+  meta?: { status?: number; errorCode?: string };
+  data?: WatchApiData;
+}
+
+/** 整形済みの動画メタデータ。 */
+export interface VideoInfo {
+  id: string;
+  title: string;
+  description: string | null;
+  durationSec: number | null;
+  registeredAt: string | null;
+  viewCount: number | null;
+  commentCount: number | null;
+  likeCount: number | null;
+  tags: string[];
+  genre: string | null;
+  uploaderName: string | null;
+  uploaderId: string | null;
+  thumbnails: { id: string; url: string }[];
+  /** ffmpeg に渡すストリーム取得に必要な内部情報。 */
+  formats: FormatInfo[];
+  /** ストリーム取得で利用する生の watch データ。 */
+  raw: WatchApiData;
+}
+
+/** 選択可能な映像/音声フォーマット。 */
+export interface FormatInfo {
+  videoId: string;
+  audioId: string;
+  width?: number;
+  height?: number;
+  videoBitRate?: number;
+  audioBitRate?: number;
+  /** 概算の総ビットレート（bps）。品質ソート用。 */
+  totalBitRate: number;
+  label: string;
+}
+
+export type QualitySelector =
+  | "best"
+  | "worst"
+  | ((formats: FormatInfo[]) => FormatInfo);
+
+export interface ClientOptions {
+  /** 既存セッションの user_session Cookie。指定するとログイン済み扱い。 */
+  userSession?: string;
+  /** "a=b; c=d" 形式の Cookie ヘッダ文字列をまとめて投入。 */
+  cookie?: string;
+  /** User-Agent を上書き。 */
+  userAgent?: string;
+  /** fetch 実装の差し替え（テスト用）。 */
+  fetch?: typeof fetch;
+}
+
+export interface StreamOptions {
+  /** 取得する品質。既定は "best"。 */
+  quality?: QualitySelector;
+  /**
+   * 出力コンテナ。
+   * - "mp4": フラグメント mp4（パイプ向け、既定）
+   * - "matroska": mkv
+   * - "mpegts": ts
+   */
+  container?: "mp4" | "matroska" | "mpegts";
+  /** ffmpeg 実行ファイルのパス。未指定なら ffmpeg-static → PATH の順で解決。 */
+  ffmpegPath?: string;
+  /** ffmpeg に追加で渡す引数。 */
+  extraArgs?: string[];
+  /** AbortSignal で中断可能。 */
+  signal?: AbortSignal;
+}

--- a/niconico-dl/src/watch.ts
+++ b/niconico-dl/src/watch.ts
@@ -1,0 +1,236 @@
+import { CookieJar } from "./cookies.js";
+import {
+  LoginRequiredError,
+  NiconicoError,
+  VideoUnavailableError,
+} from "./errors.js";
+import type {
+  DomandSource,
+  FormatInfo,
+  VideoInfo,
+  WatchApiData,
+  WatchApiResponse,
+} from "./types.js";
+
+const API_BASE = "https://nvapi.nicovideo.jp";
+const BASE_URL = "https://www.nicovideo.jp";
+
+const FRONTEND_HEADERS = {
+  "X-Frontend-ID": "6",
+  "X-Frontend-Version": "0",
+} as const;
+
+// FORBIDDEN / NOT_FOUND など、ログインで解決し得る理由コード。
+const LOGIN_REASON_CODES = new Set([
+  "CHANNEL_MEMBER_ONLY",
+  "HARMFUL_VIDEO",
+  "HIDDEN_VIDEO",
+  "PPV_VIDEO",
+  "PREMIUM_ONLY",
+]);
+
+/** URL もしくは ID 文字列から watch ID（例: sm9, so12345, 12345）を抽出。 */
+export function extractVideoId(input: string): string {
+  const m = input.match(/(?:nicovideo\.jp\/watch\/|nico\.ms\/)?((?:[a-z]{2})?\d+)/i);
+  if (!m?.[1]) throw new NiconicoError(`動画 ID を解釈できません: ${input}`);
+  return m[1];
+}
+
+function genActionTrackId(): string {
+  // yt-dlp と同じ形式: 固定プレフィックス + ミリ秒タイムスタンプ。
+  return `AAAAAAAAAA_${Date.now()}`;
+}
+
+interface FetchDeps {
+  jar: CookieJar;
+  userAgent: string;
+  fetchImpl: typeof fetch;
+}
+
+/** watch API を叩き、整形済みメタデータを返す。 */
+export async function fetchVideoInfo(
+  videoId: string,
+  deps: FetchDeps,
+): Promise<VideoInfo> {
+  const loggedIn = deps.jar.has("user_session");
+  const path = loggedIn ? "v3" : "v3_guest";
+  const url = `${BASE_URL}/api/watch/${path}/${videoId}?actionTrackId=${encodeURIComponent(
+    genActionTrackId(),
+  )}`;
+
+  const res = await deps.fetchImpl(url, {
+    headers: {
+      ...FRONTEND_HEADERS,
+      "User-Agent": deps.userAgent,
+      Cookie: deps.jar.toHeader(),
+    },
+  });
+  deps.jar.setFromResponse(res);
+
+  let body: WatchApiResponse;
+  try {
+    body = (await res.json()) as WatchApiResponse;
+  } catch {
+    throw new NiconicoError(`watch API のレスポンスを解釈できません (HTTP ${res.status})`);
+  }
+
+  const status = body.meta?.status ?? res.status;
+  if (status !== 200) {
+    throwForError(body);
+  }
+
+  const data = body.data;
+  if (!data) throw new NiconicoError("watch API に data がありません");
+
+  return buildVideoInfo(videoId, data);
+}
+
+function throwForError(body: WatchApiResponse): never {
+  const code = body.meta?.errorCode?.toUpperCase();
+  const reason = body.data?.reasonCode;
+
+  if (reason === "DOMESTIC_VIDEO" || reason === "HIGH_RISK_COUNTRY_VIDEO") {
+    throw new VideoUnavailableError(
+      "地域制限により取得できません（日本国内限定）",
+      code,
+      reason,
+    );
+  }
+  if (reason && LOGIN_REASON_CODES.has(reason)) {
+    throw new LoginRequiredError(`ログインが必要です (${reason})`);
+  }
+  throw new VideoUnavailableError(
+    `動画を取得できません (status=${body.meta?.status}, code=${code ?? "不明"}, reason=${reason ?? "不明"})`,
+    code,
+    reason,
+  );
+}
+
+function buildFormats(data: WatchApiData): FormatInfo[] {
+  const videos = (data.media?.domand?.videos ?? []).filter(
+    (v): v is DomandSource => Boolean(v.isAvailable && v.id),
+  );
+  const audios = (data.media?.domand?.audios ?? []).filter(
+    (a): a is DomandSource => Boolean(a.isAvailable && a.id),
+  );
+  if (videos.length === 0 || audios.length === 0) return [];
+
+  // 各画質の映像に、最高ビットレートの音声を組み合わせる。
+  const bestAudio = audios.reduce((a, b) =>
+    (b.bitRate ?? 0) > (a.bitRate ?? 0) ? b : a,
+  );
+
+  return videos
+    .map((v): FormatInfo => {
+      const vBr = v.bitRate ?? 0;
+      const aBr = bestAudio.bitRate ?? 0;
+      return {
+        videoId: v.id,
+        audioId: bestAudio.id,
+        width: v.width,
+        height: v.height,
+        videoBitRate: v.bitRate,
+        audioBitRate: bestAudio.bitRate,
+        totalBitRate: vBr + aBr,
+        label: v.label ?? (v.height ? `${v.height}p` : v.id),
+      };
+    })
+    .sort((a, b) => a.totalBitRate - b.totalBitRate);
+}
+
+function buildVideoInfo(videoId: string, data: WatchApiData): VideoInfo {
+  const thumbs = data.video?.thumbnail ?? {};
+  const thumbnails = Object.entries(thumbs)
+    .filter(([, url]) => typeof url === "string" && url)
+    .map(([id, url]) => ({ id, url }));
+
+  const owner = data.owner;
+  const channel = data.channel;
+
+  return {
+    id: data.video?.id ?? videoId,
+    title: data.video?.title ?? "",
+    description: data.video?.description ?? null,
+    durationSec: data.video?.duration ?? null,
+    registeredAt: data.video?.registeredAt ?? null,
+    viewCount: data.video?.count?.view ?? null,
+    commentCount: data.video?.count?.comment ?? null,
+    likeCount: data.video?.count?.like ?? null,
+    tags: (data.tag?.items ?? [])
+      .map((t) => t.name)
+      .filter((n): n is string => Boolean(n)),
+    genre: data.genre?.label ?? null,
+    uploaderName: channel?.name ?? owner?.nickname ?? null,
+    uploaderId:
+      channel?.id != null
+        ? String(channel.id)
+        : owner?.id != null
+          ? String(owner.id)
+          : null,
+    thumbnails,
+    formats: buildFormats(data),
+    raw: data,
+  };
+}
+
+export interface HlsResult {
+  /** ffmpeg に渡す m3u8 (master playlist) URL。 */
+  contentUrl: string;
+  /** domand_bid を含む、HLS リクエストに必要な Cookie ヘッダ値。 */
+  cookieHeader: string;
+}
+
+/**
+ * access-rights/hls を叩いて m3u8 URL を取得する。
+ * レスポンスで domand_bid Cookie が払い出されるため、これを ffmpeg に渡す。
+ */
+export async function fetchHls(
+  videoId: string,
+  data: WatchApiData,
+  outputs: Array<[string, string]>,
+  deps: FetchDeps,
+): Promise<HlsResult> {
+  const accessKey = data.media?.domand?.accessRightKey;
+  const trackId = data.client?.watchTrackId;
+  if (!accessKey || !trackId) {
+    throw new NiconicoError(
+      "accessRightKey / watchTrackId が取得できません（DRM 動画またはログインが必要）",
+    );
+  }
+
+  const url = `${API_BASE}/v1/watch/${videoId}/access-rights/hls?actionTrackId=${encodeURIComponent(
+    trackId,
+  )}`;
+
+  const res = await deps.fetchImpl(url, {
+    method: "POST",
+    headers: {
+      Accept: "application/json;charset=utf-8",
+      "Content-Type": "application/json",
+      "X-Access-Right-Key": accessKey,
+      "X-Request-With": BASE_URL,
+      ...FRONTEND_HEADERS,
+      "User-Agent": deps.userAgent,
+      Cookie: deps.jar.toHeader(),
+    },
+    body: JSON.stringify({ outputs }),
+  });
+  deps.jar.setFromResponse(res);
+
+  if (!res.ok) {
+    if (res.status === 401 || res.status === 403) {
+      throw new LoginRequiredError(
+        `HLS の取得が拒否されました (HTTP ${res.status})。ログインや視聴権が必要な可能性があります`,
+      );
+    }
+    throw new NiconicoError(`access-rights/hls が失敗しました (HTTP ${res.status})`);
+  }
+
+  const json = (await res.json()) as { data?: { contentUrl?: string } };
+  const contentUrl = json.data?.contentUrl;
+  if (!contentUrl) {
+    throw new NiconicoError("contentUrl を取得できませんでした");
+  }
+
+  return { contentUrl, cookieHeader: deps.jar.toHeader() };
+}

--- a/niconico-dl/tsconfig.json
+++ b/niconico-dl/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules", "examples"]
+}

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -20,6 +20,7 @@
         "@discordjs/opus": "^0.10.0",
         "@discordjs/voice": "^0.19.2",
         "@orangebot/shared": "workspace:*",
+        "niconico-dl": "workspace:*",
         "@types/body-parser": "^1.19.6",
         "@types/cors": "^2.8.19",
         "@types/ejs": "^3.1.1",

--- a/packages/bot/src/bot/adapters/music.adapter.ts
+++ b/packages/bot/src/bot/adapters/music.adapter.ts
@@ -24,6 +24,7 @@ import { Music, PlayerData } from '../../constant/music/music.js';
 import { LogLevel, MusicService, Playlist } from '@orangebot/shared';
 import { extractPlaylistId, extractVideoId, getInnertube } from '../request/innertube.js';
 import { getPlaylistItems } from '../request/youtube.js';
+import { getNiconicoInfo, getNiconicoStream, isNiconicoUrl } from '../request/niconico.js';
 
 /**
  * キューに音楽を追加する
@@ -52,6 +53,11 @@ export async function add(
 
   if (playlistId) {
     await addYoutubeMusic(channel, 'playlist', url, false, loop, shuffle);
+    return true;
+  }
+
+  if (isNiconicoUrl(url)) {
+    await addNiconicoMusic(channel, url, false, loop, shuffle);
     return true;
   }
 
@@ -252,6 +258,101 @@ export async function addYoutubeMusic(
     }
   }
   return false;
+}
+
+/**
+ * ニコニコ動画の情報を取得し、キューに追加する
+ * @param channel
+ * @param url watch URL または 動画ID
+ * @param interrupt
+ * @param loop
+ * @param shuffle
+ * @returns
+ */
+export async function addNiconicoMusic(
+  channel: VoiceBasedChannel,
+  url: string,
+  interrupt?: boolean,
+  loop?: boolean,
+  shuffle?: boolean
+): Promise<boolean> {
+  const musicService = new MusicService();
+  const p = await updateAudioPlayer(channel);
+  const status = p.player.state.status;
+
+  let info;
+  try {
+    info = await getNiconicoInfo(url);
+  } catch (e) {
+    await Logger.put({
+      guild_id: channel.guild?.id,
+      channel_id: channel.id,
+      user_id: undefined,
+      level: LogLevel.ERROR,
+      event: 'command|music-add',
+      message: [JSON.stringify((e as Error).message)],
+    });
+    const send = new EmbedBuilder()
+      .setColor('#ff0000')
+      .setTitle('エラー')
+      .setDescription('ニコニコ動画の情報を取得できなかった (削除・非公開・会員限定の可能性)');
+
+    (channel as VoiceChannel).send({ content: `ニコニコ動画を取得できなかった…`, embeds: [send] });
+    return false;
+  }
+
+  const title = info.title;
+  const videoUrl = `https://www.nicovideo.jp/watch/${info.id}`;
+  const thumbnail = info.thumbnails[0]?.url ?? '';
+
+  await musicService.addTrack(
+    channel.guild.id,
+    channel.id,
+    {
+      title: title,
+      url: videoUrl,
+      thumbnail: thumbnail,
+    },
+    !!interrupt
+  );
+  if (interrupt) {
+    return true;
+  }
+
+  const musics = await musicService.getQueue(channel.guild.id, channel.id);
+
+  if (status === AudioPlayerStatus.Playing) {
+    const addMusic = musics.find((m) => m.url === videoUrl);
+    const description = musics.map((m) => m.music_id + ': ' + m.title).join('\n');
+
+    if (description.length >= 4000) {
+      const sliced = musics.slice(0, 20);
+      const slicedDescription = sliced.map((m) => m.music_id + ': ' + m.title).join('\n');
+
+      const send = new EmbedBuilder()
+        .setColor('#cc66cc')
+        .setAuthor({ name: `追加: (${addMusic?.music_id}) ${title}` })
+        .setTitle('キュー(先頭の20曲のみ表示しています): ')
+        .setDescription(slicedDescription)
+        .setThumbnail(thumbnail);
+
+      (channel as VoiceChannel).send({ embeds: [send] });
+      return true;
+    }
+
+    const send = new EmbedBuilder()
+      .setColor('#cc66cc')
+      .setAuthor({ name: `追加: (${addMusic?.music_id}) ${title}` })
+      .setTitle(`キュー(全${musics.length}曲): `)
+      .setDescription(description ? description : 'none')
+      .setThumbnail(thumbnail);
+
+    (channel as VoiceChannel).send({ embeds: [send] });
+    return true;
+  }
+  await initPlayerInfo(channel, !!loop, !!shuffle);
+  await playMusic(channel);
+  return true;
 }
 
 /**
@@ -540,14 +641,20 @@ export async function playMusic(channel: VoiceBasedChannel) {
   try {
     const p = await updateAudioPlayer(channel);
 
-    const videoId = extractVideoId(playing.url);
-    if (!videoId) {
-      throw new Error(`動画IDを取得できない: ${playing.url}`);
-    }
+    let resource;
+    if (isNiconicoUrl(playing.url)) {
+      const { stream } = await getNiconicoStream(playing.url);
+      resource = createAudioResource(stream);
+    } else {
+      const videoId = extractVideoId(playing.url);
+      if (!videoId) {
+        throw new Error(`動画IDを取得できない: ${playing.url}`);
+      }
 
-    const innertube = await getInnertube();
-    const stream = await innertube.download(videoId, { type: 'audio', quality: 'best', client: 'TV' });
-    const resource = createAudioResource(Readable.fromWeb(stream as WebReadableStream<Uint8Array>));
+      const innertube = await getInnertube();
+      const stream = await innertube.download(videoId, { type: 'audio', quality: 'best', client: 'TV' });
+      resource = createAudioResource(Readable.fromWeb(stream as WebReadableStream<Uint8Array>));
+    }
 
     if (info?.silent === 0) {
       const slicedMusics = musics.slice(0, 4);
@@ -863,28 +970,33 @@ export async function seek(channel: VoiceBasedChannel, seek: number): Promise<vo
     return;
   }
 
-  const videoId = extractVideoId(playing.url);
-  if (!videoId) {
+  const isNiconico = isNiconicoUrl(playing.url);
+  if (!isNiconico && !extractVideoId(playing.url)) {
     return;
   }
 
   try {
     const p = await updateAudioPlayer(channel);
 
-    const innertube = await getInnertube();
-    const stream = await innertube.download(videoId, { type: 'audio', quality: 'best', client: 'TV' });
+    let sourceStream: Readable;
+    if (isNiconico) {
+      const { stream } = await getNiconicoStream(playing.url);
+      sourceStream = stream;
+    } else {
+      const videoId = extractVideoId(playing.url)!;
+      const innertube = await getInnertube();
+      const stream = await innertube.download(videoId, { type: 'audio', quality: 'best', client: 'TV' });
+      sourceStream = Readable.fromWeb(stream as WebReadableStream<Uint8Array>);
+    }
 
     // ffmpegで指定秒数まで読み飛ばしてPCMに変換する
     const transcoder = new prism.FFmpeg({
       args: ['-analyzeduration', '0', '-loglevel', '0', '-ss', String(seek), '-i', '-', '-f', 's16le', '-ar', '48000', '-ac', '2'],
     });
 
-    const resource = createAudioResource(
-      Readable.fromWeb(stream as WebReadableStream<Uint8Array>).pipe(transcoder),
-      {
-        inputType: StreamType.Raw,
-      }
-    );
+    const resource = createAudioResource(sourceStream.pipe(transcoder), {
+      inputType: StreamType.Raw,
+    });
 
     p.player.play(resource);
 

--- a/packages/bot/src/bot/request/niconico.ts
+++ b/packages/bot/src/bot/request/niconico.ts
@@ -1,0 +1,72 @@
+import { NiconicoClient, type FormatInfo, type StreamOptions, type VideoStream } from 'niconico-dl';
+
+// ニコニコの ffmpeg は bot 起動時と同じパスに揃える (FFMPEG_PATH 環境変数 / 既定 /usr/bin/ffmpeg)
+const FFMPEG_PATH = process.env.FFMPEG_PATH;
+
+let client: NiconicoClient | undefined;
+
+/**
+ * NiconicoClient を取得する (初回呼び出し時のみ生成)
+ * 公開動画のみを対象とするためログインは行わない
+ * @returns
+ */
+export function getNiconicoClient(): NiconicoClient {
+  if (!client) {
+    client = new NiconicoClient();
+  }
+  return client;
+}
+
+/**
+ * 入力がニコニコ動画の URL または ID かどうかを判定する
+ * @param input URL or 動画ID (sm9 / so12345 / nm12345)
+ * @returns
+ */
+export function isNiconicoUrl(input: string): boolean {
+  try {
+    const u = new URL(input);
+    if (/(^|\.)nicovideo\.jp$/.test(u.hostname) && u.pathname.startsWith('/watch/')) {
+      return true;
+    }
+    return u.hostname === 'nico.ms';
+  } catch {
+    return /^(?:[a-z]{2})?\d+$/i.test(input.trim());
+  }
+}
+
+/**
+ * 音楽 bot 向けのフォーマット選択
+ * 映像は ffmpeg 側で破棄するため、音声ビットレート最優先・映像ビットレート最小で選ぶ
+ */
+function pickAudioFormat(formats: FormatInfo[]): FormatInfo {
+  return [...formats].sort(
+    (a, b) => (b.audioBitRate ?? 0) - (a.audioBitRate ?? 0) || (a.videoBitRate ?? 0) - (b.videoBitRate ?? 0)
+  )[0];
+}
+
+/**
+ * ニコニコ動画のメタデータを取得する
+ * @param urlOrId watch URL または ID
+ * @returns
+ */
+export async function getNiconicoInfo(urlOrId: string) {
+  return await getNiconicoClient().getInfo(urlOrId);
+}
+
+/**
+ * ニコニコ動画の音声ストリームを取得する
+ * 映像は破棄 (-vn) して帯域・CPU を節約する
+ * @param urlOrId watch URL または ID
+ * @param extraArgs ffmpeg への追加引数 (seek 用の -ss など)
+ * @returns
+ */
+export async function getNiconicoStream(urlOrId: string, extraArgs: string[] = []): Promise<VideoStream> {
+  const options: StreamOptions = {
+    quality: pickAudioFormat,
+    extraArgs: ['-vn', ...extraArgs],
+  };
+  if (FFMPEG_PATH) {
+    options.ffmpegPath = FFMPEG_PATH;
+  }
+  return await getNiconicoClient().getStream(urlOrId, options);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,19 @@ importers:
         specifier: ^25.0.1
         version: 25.0.1
 
+  niconico-dl:
+    dependencies:
+      ffmpeg-static:
+        specifier: ^5.0.0
+        version: 5.3.0
+    devDependencies:
+      '@types/node':
+        specifier: ^20.11.0
+        version: 20.19.43
+      typescript:
+        specifier: ^5.4.0
+        version: 5.9.3
+
   packages/bot:
     dependencies:
       '@discordjs/opus':
@@ -98,6 +111,9 @@ importers:
       mysql2:
         specifier: ^3.14.2
         version: 3.20.0(@types/node@24.12.2)
+      niconico-dl:
+        specifier: workspace:*
+        version: link:../../niconico-dl
       node-cron:
         specifier: ^4.2.1
         version: 4.2.1
@@ -889,6 +905,9 @@ packages:
 
   '@types/node@10.17.60':
     resolution: {integrity: sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==}
+
+  '@types/node@20.19.43':
+    resolution: {integrity: sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==}
 
   '@types/node@24.12.2':
     resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
@@ -2774,6 +2793,9 @@ packages:
   undefsafe@2.0.5:
     resolution: {integrity: sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==}
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
@@ -3578,6 +3600,10 @@ snapshots:
   '@types/node-cron@3.0.11': {}
 
   '@types/node@10.17.60': {}
+
+  '@types/node@20.19.43':
+    dependencies:
+      undici-types: 6.21.0
 
   '@types/node@24.12.2':
     dependencies:
@@ -5516,6 +5542,8 @@ snapshots:
   typescript@5.9.3: {}
 
   undefsafe@2.0.5: {}
+
+  undici-types@6.21.0: {}
 
   undici-types@7.16.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - 'packages/*'
+  - 'niconico-dl'


### PR DESCRIPTION
ニコニコ動画 URL/ID を YouTube と同じキュー・再生フローで再生できるようにする。

- niconico-dl を pnpm workspace に追加し bot の依存に登録
- request/niconico.ts: URL 判定・メタ取得・音声優先ストリーム取得(-vn で映像破棄)
- music.adapter.ts: add()/playMusic()/seek() にニコニコ分岐を追加
- DB スキーマ変更なし(URL パターンで再生時に分岐)
- 公開動画を対象(user_session 未使用)