### PR TITLE
fix(chat-history): systemメッセージを非永続化しtool履歴表示を改善

### DIFF
--- a/packages/bot/src/bot/manager/handlers/interactions/revert.handler.ts
+++ b/packages/bot/src/bot/manager/handlers/interactions/revert.handler.ts
@@ -1,7 +1,7 @@
 import { CacheType, ChatInputCommandInteraction, EmbedBuilder } from 'discord.js';
 import { BaseInteractionHandler } from '../../interaction.handler.js';
 import { Logger } from '../../../../common/logger.js';
-import { ChatHistory, ChatHistoryRepository, ChatSession } from '@orangebot/shared';
+import { ChatHistory, ChatHistoryRepository, ChatSession, countNonSystemMessages } from '@orangebot/shared';
 import { DISCORD_CLIENT } from '../../../../constant/constants.js';
 import { getIdInfoInteraction } from '../../../../constant/chat/chat.js';
 import { createChatService } from '../../../adapters/chat.adapter.js';
@@ -87,7 +87,7 @@ export class RevertHandler extends BaseInteractionHandler {
         .setColor('#00ff00')
         .setTitle('復元完了')
         .setDescription(
-          `チャット履歴を復元しました。\n履歴UUID: ${chatHistory.uuid}\nメッセージ数: ${chatHistory.content.length - 1}`
+          `チャット履歴を復元しました。\n履歴UUID: ${chatHistory.uuid}\nメッセージ数: ${countNonSystemMessages(chatHistory.content)}`
         );
 
       await interaction.editReply({ embeds: [successEmbed] });

--- a/packages/bot/src/controller/chatRouter.ts
+++ b/packages/bot/src/controller/chatRouter.ts
@@ -1,6 +1,6 @@
 import Express from 'express';
 import { Logger } from '../common/logger.js';
-import { ChatHistoryRepository } from "@orangebot/shared";
+import { ChatHistoryRepository, stripSystemMessages } from "@orangebot/shared";
 
 export const chatRouter = Express.Router();
 
@@ -70,7 +70,7 @@ chatRouter.get('/chat/history/:uuid', async (req: Express.Request, res: Express.
     res.render('chatHistory', {
       chatHistory: {
         ...chatHistory,
-        content: chatHistory.content.slice(1),
+        content: stripSystemMessages(chatHistory.content),
       }
     });
   } catch (error) {

--- a/packages/bot/views/chatHistory.ejs
+++ b/packages/bot/views/chatHistory.ejs
@@ -40,6 +40,10 @@
             background-color: #fff3e0;
             border-left: 4px solid #ff9800;
         }
+        .message.tool {
+            background-color: #e8f5e9;
+            border-left: 4px solid #009688;
+        }
         .role-badge {
             font-size: 0.8em;
             font-weight: bold;
@@ -49,6 +53,37 @@
         .message-content {
             white-space: pre-line;
             overflow-wrap: anywhere;
+        }
+        .tool-call-box {
+            border: 1px solid #b2dfdb;
+            border-radius: 8px;
+            background-color: #ffffff;
+            padding: 10px 12px;
+            margin-top: 8px;
+        }
+        .tool-call-box .tool-name {
+            font-weight: bold;
+            color: #00796b;
+            word-break: break-all;
+        }
+        .tool-call-box .tool-id {
+            font-size: 0.75em;
+            color: #6c757d;
+            word-break: break-all;
+        }
+        .tool-call-box pre,
+        .tool-result-content pre {
+            background-color: #f8f9fa;
+            border: 1px solid #e9ecef;
+            border-radius: 4px;
+            padding: 8px;
+            margin-bottom: 0;
+            overflow-x: auto;
+            white-space: pre-wrap;
+            overflow-wrap: anywhere;
+        }
+        .tool-result-content {
+            margin-top: 4px;
         }
         .image-content {
             max-width: 100%;
@@ -73,6 +108,47 @@
 </head>
 
 <body>
+    <%
+        // ツール呼び出しの引数 / ツール結果を見やすく整形する。
+        // JSON としてパースできる場合は整形し、できない場合は元の文字列をそのまま返す。
+        function formatMaybeJson(value) {
+            if (value === null || value === undefined) {
+                return '';
+            }
+            if (typeof value !== 'string') {
+                try {
+                    return JSON.stringify(value, null, 2);
+                } catch (e) {
+                    return String(value);
+                }
+            }
+            const trimmed = value.trim();
+            if (trimmed === '') {
+                return '';
+            }
+            try {
+                return JSON.stringify(JSON.parse(trimmed), null, 2);
+            } catch (e) {
+                return value;
+            }
+        }
+        // role: 'tool' のメッセージから content を文字列として取り出す。
+        function extractToolText(content) {
+            if (content === null || content === undefined) {
+                return '';
+            }
+            if (typeof content === 'string') {
+                return content;
+            }
+            if (Array.isArray(content)) {
+                return content
+                    .map((part) => (part && part.type === 'text' && typeof part.text === 'string' ? part.text : ''))
+                    .filter((text) => text !== '')
+                    .join('\n');
+            }
+            return String(content);
+        }
+    %>
     <div class="chat-container">
         <h1 class="mb-4">チャット履歴</h1>
 
@@ -90,10 +166,23 @@
         <div class="messages">
             <% chatHistory.content.forEach((message, index) => { %>
                 <div class="message <%= message.role %>">
-                    <div class="role-badge text-<%= message.role === 'system' ? 'secondary' : message.role === 'user' ? 'primary' : message.role === 'assistant' ? 'success' : 'warning' %>">
-                        <%= message.role === 'assistant' ? chatHistory.bot_info.name : message.role %>
+                    <div class="role-badge text-<%= message.role === 'system' ? 'secondary' : message.role === 'user' ? 'primary' : message.role === 'assistant' ? 'success' : message.role === 'tool' ? 'info' : 'warning' %>">
+                        <% if (message.role === 'assistant') { %><%= (chatHistory.bot_info && chatHistory.bot_info.name) ? chatHistory.bot_info.name : 'assistant' %><% } else if (message.role === 'tool') { %>🔧 TOOL<% } else { %><%= message.role %><% } %>
                         <% if (message.name) { %> - <%= message.name %><% } %>
                     </div>
+
+                    <% if (message.role === 'tool') {
+                        const toolText = extractToolText(message.content);
+                        const formattedTool = formatMaybeJson(toolText);
+                    %>
+                        <% if (message.tool_call_id) { %>
+                            <div class="tool-id mb-1">tool_call_id: <%= message.tool_call_id %></div>
+                        <% } %>
+                        <div class="tool-result-content"><%
+                            if (formattedTool === '') { %><em class="text-muted">結果なし</em><%
+                            } else { %><pre><%= formattedTool %></pre><% }
+                        %></div>
+                    <% } else { %>
 
                     <div class="message-content"><%
                         if (typeof message.content === 'string') { %><%- message.content.replace(/\n/g, '<br>') %><%
@@ -125,11 +214,21 @@
 
                     <% if (message.tool_calls && message.tool_calls.length > 0) { %>
                         <div class="tool-calls mt-2">
-                            <small class="text-muted">ツール呼び出し:</small>
-                            <% message.tool_calls.forEach((toolCall, toolIndex) => { %>
-                                <div class="bg-light p-2 mt-1 rounded">
-                                    <strong><%= toolCall.function.name %></strong>
-                                    <pre class="mb-0"><%= toolCall.function.arguments %></pre>
+                            <small class="text-muted">ツール呼び出し (<%= message.tool_calls.length %>件):</small>
+                            <% message.tool_calls.forEach((toolCall, toolIndex) => {
+                                const fn = toolCall.function || {};
+                                const formattedArgs = formatMaybeJson(fn.arguments);
+                            %>
+                                <div class="tool-call-box">
+                                    <div class="d-flex justify-content-between align-items-start flex-wrap">
+                                        <span class="tool-name">🔧 <%= fn.name || '(不明なツール)' %></span>
+                                        <% if (toolCall.id) { %><span class="tool-id">id: <%= toolCall.id %></span><% } %>
+                                    </div>
+                                    <% if (formattedArgs === '') { %>
+                                        <small class="text-muted d-block mt-1">引数なし</small>
+                                    <% } else { %>
+                                        <pre class="mt-1"><%= formattedArgs %></pre>
+                                    <% } %>
                                 </div>
                             <% }) %>
                         </div>
@@ -139,6 +238,7 @@
                         <div class="refusal mt-2">
                             <small class="text-danger">拒否理由: <%= message.refusal %></small>
                         </div>
+                    <% } %>
                     <% } %>
                 </div>
             <% }) %>

--- a/packages/bot/views/chatHistoryList.ejs
+++ b/packages/bot/views/chatHistoryList.ejs
@@ -111,9 +111,19 @@
                                                         lastContent = '[マルチメディアコンテンツ]';
                                                     }
                                                 }
+                                                if (lastMessage.role === 'tool') {
+                                                    lastContent = lastContent || '[ツール実行結果]';
+                                                } else if (lastMessage.tool_calls && lastMessage.tool_calls.length > 0 && !lastContent) {
+                                                    const toolNames = lastMessage.tool_calls
+                                                        .map(call => call.function && call.function.name)
+                                                        .filter(Boolean)
+                                                        .join(', ');
+                                                    lastContent = toolNames ? `[ツール呼び出し: ${toolNames}]` : '[ツール呼び出し]';
+                                                }
+                                                const lastRoleLabel = lastMessage.role === 'tool' ? '🔧 tool' : lastMessage.role;
                                             %>
                                                 <div class="last-message truncate">
-                                                    <strong><%= lastMessage.role %>:</strong> <%= lastContent %>
+                                                    <strong><%= lastRoleLabel %>:</strong> <%= lastContent %>
                                                 </div>
                                             <% } %>
 
@@ -131,7 +141,7 @@
 
                                             <div class="mt-2">
                                                 <span class="badge bg-secondary">
-                                                    <%= history.content ? history.content.length - 1 : 0 %>件のメッセージ
+                                                    <%= history.content ? history.content.filter(message => message.role !== 'system').length : 0 %>件のメッセージ
                                                 </span>
                                             </div>
                                         </div>

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -7,6 +7,7 @@ export * from './common/random.js';
 export * from './constants/dice.js';
 export * from './constants/gacha.js';
 export * from './services/index.js';
+export * from './utils/chatHistory.js';
 
 // Models entry namespace - export both as namespace and as individual names
 export * as Models from './models/index.js';

--- a/packages/shared/src/repository/chatHistoryRepository.ts
+++ b/packages/shared/src/repository/chatHistoryRepository.ts
@@ -1,6 +1,7 @@
 import { DeepPartial, Repository } from 'typeorm';
 import * as Models from '../models/index.js';
 import { getDataSource } from '../config/datasource.js';
+import { stripSystemMessages } from '../utils/chatHistory.js';
 
 export class ChatHistoryRepository {
   private repository: Repository<Models.ChatHistory>;
@@ -87,7 +88,14 @@ export class ChatHistoryRepository {
    * @returns Promise<void>
    */
   public async save(chatHistory: DeepPartial<Models.ChatHistory>): Promise<void> {
-    await this.repository.save(chatHistory);
+    await this.repository.save(
+      chatHistory.content
+        ? {
+            ...chatHistory,
+            content: stripSystemMessages(chatHistory.content as Models.ChatHistory['content']),
+          }
+        : chatHistory
+    );
   }
 
   /**
@@ -103,7 +111,7 @@ export class ChatHistoryRepository {
       // 既存のレコードがある場合は content を更新
       await this.repository.save({
         uuid,
-        content,
+        content: stripSystemMessages(content),
       });
     } else {
       // 既存のレコードがない場合はエラーを投げる（UUIDが存在しない）

--- a/packages/shared/src/services/chat.service.ts
+++ b/packages/shared/src/services/chat.service.ts
@@ -11,6 +11,7 @@ import {
   ChatSession,
   LiteLLMMode,
 } from '../types/chat.js';
+import { prependSystemMessageIfMissing } from '../utils/chatHistory.js';
 
 /** ユニットテストでリポジトリをモックできるよう、利用メソッドのみを依存として宣言する */
 type UsersRepositoryLike = Pick<UsersRepository, 'getUserSetting'>;
@@ -95,7 +96,7 @@ export class ChatService {
     isGuild: boolean
   ): ChatSession {
     const session = this.createSession(id, history.model, history.mode as LiteLLMMode, isGuild);
-    session.chat = history.chat;
+    session.chat = prependSystemMessageIfMissing(history.chat, session.chat[0]);
     session.uuid = history.uuid;
     return session;
   }

--- a/packages/shared/src/utils/chatHistory.ts
+++ b/packages/shared/src/utils/chatHistory.ts
@@ -1,0 +1,35 @@
+import { ChatCompletionMessageParam } from 'openai/resources';
+import { ChatRole } from '../types/chat.js';
+
+export function isSystemMessage(message: ChatCompletionMessageParam): boolean {
+  return message.role === ChatRole.SYSTEM;
+}
+
+/**
+ * DB に保存する/DB から復元する会話履歴から、システムプロンプトを除外する。
+ *
+ * セッション上の system メッセージは LLM 呼び出しに必要なため、呼び出し側の配列は変更せず、
+ * 永続化対象だけを新しい配列として返す。
+ */
+export function stripSystemMessages(content: readonly ChatCompletionMessageParam[]): ChatCompletionMessageParam[] {
+  return content.filter((message) => !isSystemMessage(message));
+}
+
+/**
+ * DB には system メッセージがない前提でも、セッション復元時には必要に応じて先頭へ戻す。
+ *
+ * 旧データのように既に system メッセージが含まれている場合は重複させない。
+ */
+export function prependSystemMessageIfMissing(
+  content: readonly ChatCompletionMessageParam[],
+  systemMessage?: ChatCompletionMessageParam
+): ChatCompletionMessageParam[] {
+  if (!systemMessage || content.some(isSystemMessage)) {
+    return [...content];
+  }
+  return [systemMessage, ...content];
+}
+
+export function countNonSystemMessages(content: readonly ChatCompletionMessageParam[]): number {
+  return stripSystemMessages(content).length;
+}

--- a/packages/shared/test/unit/chat.service.test.ts
+++ b/packages/shared/test/unit/chat.service.test.ts
@@ -69,9 +69,23 @@ describe('ChatService セッション管理', () => {
       true
     );
     expect(session.uuid).toBe('restored-uuid');
-    expect(session.chat).toBe(chat);
+    expect(session.chat).toEqual([{ role: ChatRole.SYSTEM, content: 'system prompt' }, ...chat]);
     expect(session.model).toBe('model-low');
     expect(service.getSessionByUuid('restored-uuid')).toBe(session);
+  });
+
+  it('restoreSession は既に system ロールが含まれる旧データでは重複追加しない', () => {
+    const { service } = makeService();
+    const chat = [
+      { role: ChatRole.SYSTEM, content: 'old system prompt' },
+      { role: ChatRole.USER, content: 'hello' },
+    ];
+    const session = service.restoreSession(
+      '100',
+      { uuid: 'restored-uuid', chat, model: 'model-low', mode: 'default' },
+      true
+    );
+    expect(session.chat).toEqual(chat);
   });
 
   it('toggleMemory はセッションがなければ null', () => {
@@ -161,6 +175,33 @@ describe('ChatService.saveHistory', () => {
     });
     expect(saveSpy).toHaveBeenCalledWith(
       expect.objectContaining({ uuid: 'u-2', channel_type: ChatHistoryChannelType.DM })
+    );
+  });
+
+  it('content はセッション上の内容をそのままリポジトリへ渡す', async () => {
+    const saveSpy = vi.fn().mockResolvedValue(undefined);
+    const { service } = makeService({ saveSpy });
+    const content = [
+      { role: ChatRole.SYSTEM, content: 'system prompt' },
+      { role: ChatRole.USER, content: 'hello' },
+      { role: ChatRole.ASSISTANT, content: 'hi' },
+    ];
+
+    await service.saveHistory({
+      uuid: 'u-3',
+      botId: 'bot-1',
+      channelId: '100',
+      name: 'guild-name',
+      content,
+      model: 'model-default',
+      mode: 'default',
+      isGuild: true,
+    });
+
+    expect(saveSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content,
+      })
     );
   });
 });

--- a/packages/shared/test/unit/chatHistoryRepository.test.ts
+++ b/packages/shared/test/unit/chatHistoryRepository.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChatHistoryRepository } from '../../src/repository/chatHistoryRepository.js';
+import { ChatRole } from '../../src/types/chat.js';
+
+const repository = {
+  save: vi.fn().mockResolvedValue(undefined),
+  findOne: vi.fn(),
+  createQueryBuilder: vi.fn(),
+  find: vi.fn(),
+  softDelete: vi.fn(),
+  delete: vi.fn(),
+};
+
+vi.mock('../../src/config/datasource.js', () => ({
+  getDataSource: () => ({
+    getRepository: () => repository,
+  }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  repository.save.mockResolvedValue(undefined);
+});
+
+describe('ChatHistoryRepository.save', () => {
+  it('保存時だけ system ロールのメッセージを除外する', async () => {
+    const chatHistoryRepository = new ChatHistoryRepository();
+    const content = [
+      { role: ChatRole.SYSTEM, content: 'system prompt' },
+      { role: ChatRole.USER, content: 'hello' },
+      { role: ChatRole.ASSISTANT, content: 'hi' },
+    ];
+
+    await chatHistoryRepository.save({ uuid: 'u-1', content });
+
+    expect(repository.save).toHaveBeenCalledWith({
+      uuid: 'u-1',
+      content: [
+        { role: ChatRole.USER, content: 'hello' },
+        { role: ChatRole.ASSISTANT, content: 'hi' },
+      ],
+    });
+    expect(content).toEqual([
+      { role: ChatRole.SYSTEM, content: 'system prompt' },
+      { role: ChatRole.USER, content: 'hello' },
+      { role: ChatRole.ASSISTANT, content: 'hi' },
+    ]);
+  });
+});

--- a/packages/speak/src/bot/dot_function/chat.ts
+++ b/packages/speak/src/bot/dot_function/chat.ts
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs';
 import { EmbedBuilder, Message } from 'discord.js';
 import { ChatCompletionContentPart } from 'openai/resources';
-import { ChatHistoryChannelType, ChatHistoryRepository, LogLevel } from '@orangebot/shared';
+import { ChatHistoryChannelType, ChatHistoryRepository, LogLevel, stripSystemMessages } from '@orangebot/shared';
 import { Logger } from '../../common/logger.js';
 import { LiteLLMModel } from '../../config/config.js';
 import { DISCORD_CLIENT } from '../../constant/constants.js';
@@ -105,7 +105,7 @@ export async function talk(message: Message, content: string, model: LiteLLMMode
       bot_id: DISCORD_CLIENT.user!.id,
       channel_id: id,
       name: message.author.displayName,
-      content: llm.chat,
+      content: stripSystemMessages(llm.chat),
       model: llm.model,
       mode: ChatService.LiteLLMMode.DEFAULT,
       channel_type: isGuild ? ChatHistoryChannelType.GUILD : ChatHistoryChannelType.DM,

--- a/packages/speak/src/bot/function/chat.ts
+++ b/packages/speak/src/bot/function/chat.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { CacheType, ChatInputCommandInteraction, EmbedBuilder } from 'discord.js';
-import { ChatHistoryRepository, LogLevel, Models } from '@orangebot/shared';
+import { ChatHistoryRepository, LogLevel, Models, countNonSystemMessages, prependSystemMessageIfMissing } from '@orangebot/shared';
 import { Logger } from '../../common/logger.js';
 import { CONFIG, LiteLLMModel } from '../../config/config.js';
 import { DISCORD_CLIENT } from '../../constant/constants.js';
@@ -142,14 +142,18 @@ export async function revert(interaction: ChatInputCommandInteraction<CacheType>
         chatHistory.mode as ChatService.LiteLLMMode,
         isGuild
       );
-      ChatService.llmList.llm.push({ ...llm, chat: chatHistory.content, uuid: chatHistory.uuid });
+      ChatService.llmList.llm.push({
+        ...llm,
+        chat: prependSystemMessageIfMissing(chatHistory.content, llm.chat[0]),
+        uuid: chatHistory.uuid,
+      });
     }
 
     const successEmbed = new EmbedBuilder()
       .setColor('#00ff00')
       .setTitle('復元完了')
       .setDescription(
-        `チャット履歴を復元しました。\n履歴UUID: ${chatHistory.uuid}\nメッセージ数: ${chatHistory.content.length - 1}`
+        `チャット履歴を復元しました。\n履歴UUID: ${chatHistory.uuid}\nメッセージ数: ${countNonSystemMessages(chatHistory.content)}`
       );
 
     await interaction.editReply({ embeds: [successEmbed] });


### PR DESCRIPTION
- チャット履歴保存時にsystemメッセージを除外
  - 履歴復元時にsystemメッセージを必要に応じて補完
  - systemを除外したメッセージ数カウントへ修正
  - toolメッセージとtool_callsの履歴表示を改善
  - system除外保存と履歴復元のユニットテストを追加